### PR TITLE
Fix h_flex import and unused imports, bump to v0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chatty"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]

--- a/src/auto_updater/installer.rs
+++ b/src/auto_updater/installer.rs
@@ -5,12 +5,16 @@
 //! - Linux: Extract tarball, rsync binary
 //! - Windows: Launch installer with silent flags
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+use std::path::PathBuf;
 use std::process::Command;
 
 use tracing::info;
+#[cfg(target_os = "macos")]
+use tracing::debug;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-use tracing::{debug, warn};
+use tracing::warn;
 
 /// Error type for installation operations
 #[derive(Debug, thiserror::Error)]

--- a/src/chatty/views/titlebar.rs
+++ b/src/chatty/views/titlebar.rs
@@ -2,7 +2,7 @@ use super::SidebarView;
 use gpui::*;
 
 #[cfg(any(target_os = "linux", target_os = "windows"))]
-use gpui_component::{Icon, IconName, Sizable, TitleBar, button::Button};
+use gpui_component::{Icon, IconName, Sizable, TitleBar, button::Button, h_flex};
 
 /// Custom titlebar component for Linux and Windows.
 /// On macOS, this renders nothing (uses native traffic lights).


### PR DESCRIPTION
- Add h_flex import to titlebar.rs for Linux/Windows builds
- Fix unused PathBuf and debug imports in installer.rs with cfg attributes

https://claude.ai/code/session_0127xXCitX9zW5GcEsJ861dg