### PR TITLE
Add GitHub release trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*" # Trigger on version tags like v0.1.0, v1.0.0, etc.
+  release:
+    types: [published] # Trigger when a release is published via GitHub UI
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,8 +24,15 @@ jobs:
       - name: Extract and validate version
         id: version
         run: |
+          # Get tag name from either push event or release event
+          if [ "${{ github.event_name }}" == "release" ]; then
+            TAG_NAME="${{ github.event.release.tag_name }}"
+          else
+            TAG_NAME="${GITHUB_REF_NAME}"
+          fi
+
           # Extract version from tag (remove 'v' prefix)
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${TAG_NAME#v}"
           echo "Tag version: $TAG_VERSION"
 
           # Extract version from Cargo.toml
@@ -167,13 +176,13 @@ jobs:
           echo "Generated checksums:"
           cat checksums.txt
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          tag_name: v${{ needs.validate-version.outputs.version }}
+          name: Release v${{ needs.validate-version.outputs.version }}
           draft: false
-          prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
+          prerelease: ${{ contains(needs.validate-version.outputs.version, '-alpha') || contains(needs.validate-version.outputs.version, '-beta') || contains(needs.validate-version.outputs.version, '-rc') }}
           generate_release_notes: true
           files: release-assets/*
         env:


### PR DESCRIPTION
- Add `release: types: [published]` trigger so the workflow runs when
  releases are created via the GitHub web interface
- Update version extraction to handle both push and release events
- Use validated version output consistently in the release step

https://claude.ai/code/session_01PijRm3yRSGwm7WGSV8uTFo