### PR TITLE
Add GITHUB_TOKEN env to dependency workflow

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Run Claude Dependency Triage
         uses: anthropics/claude-code-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--allowed-tools "Read,WebFetch,WebSearch,Bash(cargo *),Bash(jq *),Bash(gh issue *)"'


### PR DESCRIPTION
The gh CLI needs GITHUB_TOKEN to authenticate when creating issues. Without this, Claude could generate the issue creation commands but they would fail with authentication errors.

https://claude.ai/code/session_01AHwKQt5EhEkujTaBaWBQwF