### PR TITLE
Fix dependency pipeline: Use explicit colon syntax for gh issue permissions

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowed-tools "Read,WebFetch,WebSearch,Bash(cargo *),Bash(jq *),Bash(gh issue *)"'
+          claude_args: '--allowed-tools "Read,WebFetch,WebSearch,Bash(cargo *),Bash(jq *),Bash(gh issue create:*),Bash(gh issue list:*)"'
           prompt: |
             # Dependency Update Check for Chatty Release
 


### PR DESCRIPTION
Changes Bash(gh issue *) to Bash(gh issue create:*),Bash(gh issue list:*) to match the working pattern from claude-code-review.yml workflow.

The wildcard syntax was not matching gh issue create commands, causing "requires approval" errors. Using explicit colon syntax resolves this.

https://claude.ai/code/session_01AHwKQt5EhEkujTaBaWBQwF