### PR TITLE
Fix compilation error in auto_updater

### DIFF
--- a/src/auto_updater/mod.rs
+++ b/src/auto_updater/mod.rs
@@ -305,7 +305,7 @@ impl AutoUpdater {
     /// to Error so the user can see diagnostic information.
     ///
     /// Should be called during app initialization on macOS.
-    pub fn check_previous_update_status(&self, _cx: &mut App) {
+    pub fn check_previous_update_status(&self, cx: &mut App) {
         #[cfg(target_os = "macos")]
         {
             use std::path::PathBuf;


### PR DESCRIPTION
## Summary
- Fixed compilation error caused by unused parameter prefix in `check_previous_update_status()`
- Removed leading underscore from `_cx` parameter that was actually being used

## Details
The `check_previous_update_status()` method had a parameter named `_cx` (marked as unused), but the code on line 328 tries to use `cx` to update global state. This caused a compilation error.

The fix simply removes the leading underscore so the parameter name matches its usage.

## Test plan
- Build should now succeed without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)