### PR TITLE
Update rig-core from 0.30.0 to 0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "chatty"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chatty"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Upgrade rig-core to pick up structured outputs support, rustls as
default TLS backend, conversation history in streaming responses,
improved reasoning block handling, and bug fixes for agentic loop
stream termination, Ollama embedding models, and Anthropic/OpenAI
content block errors.

rmcp remains at 0.13 as rig-core 0.31.0 pins that version internally
and the types must match at the rmcp_tools() boundary. rmcp cannot be
independently upgraded to 0.16 until rig-core updates its own rmcp
dependency.

Closes #101

https://claude.ai/code/session_01Xq22QYsi5SxG1hubFqQhP4