### PR TITLE
Fix cmd-n shortcut conflict between new conversation and deny

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "chatty"
-version = "0.1.35"
+version = "0.1.37"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chatty"
-version = "0.1.36"
+version = "0.1.37"
 edition = "2024"
 
 [dependencies]

--- a/src/chatty/views/approval_prompt_bar.rs
+++ b/src/chatty/views/approval_prompt_bar.rs
@@ -69,13 +69,13 @@ impl RenderOnce for ApprovalPromptBar {
         // Platform-specific button labels
         #[cfg(target_os = "macos")]
         let (approve_label, deny_label, details_label) =
-            ("Approve (⌘Y)", "Deny (⌘N)", "Details (⌘D)");
+            ("Approve (⌘Y)", "Deny (⇧⌘N)", "Details (⌘D)");
         #[cfg(target_os = "linux")]
         let (approve_label, deny_label, details_label) =
-            ("Approve (Opt+Y)", "Deny (Opt+N)", "Details (Opt+D)");
+            ("Approve (Opt+Y)", "Deny (Shift+Opt+N)", "Details (Opt+D)");
         #[cfg(target_os = "windows")]
         let (approve_label, deny_label, details_label) =
-            ("Approve (Ctrl+Y)", "Deny (Ctrl+N)", "Details (Ctrl+D)");
+            ("Approve (Ctrl+Y)", "Deny (Shift+Ctrl+N)", "Details (Ctrl+D)");
 
         // Note: Keyboard shortcuts are handled at the ChatView level, not here.
         // This component just displays the approval bar UI.

--- a/src/chatty/views/chat_view.rs
+++ b/src/chatty/views/chat_view.rs
@@ -966,7 +966,7 @@ impl Render for ChatView {
                                 });
                                 cx.stop_propagation();
                             }
-                            "n" => {
+                            "n" if modifiers.shift => {
                                 warn!("Deny shortcut triggered in ChatView");
                                 view_entity_for_keys.update(cx, |view, cx| {
                                     view.handle_floating_approval(false, cx);


### PR DESCRIPTION
## Summary
- **Fixed** `cmd-n` shortcut conflict: it was bound to both "New Conversation" (global) and "Deny shell command" (approval bar)
- Changed deny shortcut from `cmd-n` to `cmd-shift-n` (`⇧⌘N` on macOS)
- Updated approval bar UI labels on all platforms to reflect the new shortcut
- Bumped version to 0.1.37

Closes #134

## Test plan
- [x] Press `cmd-n` — should create a new conversation (no conflict)
- [x] When approval bar is visible, press `cmd-shift-n` — should deny the command
- [x] Verify approval bar shows correct shortcut labels (`⇧⌘N` on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)