### PR TITLE
Auto-scroll to bottom when opening historic conversations

### DIFF
--- a/src/chatty/views/chat_view.rs
+++ b/src/chatty/views/chat_view.rs
@@ -846,6 +846,7 @@ impl ChatView {
             }
         }
 
+        self.scroll_to_bottom();
         cx.notify();
     }
 


### PR DESCRIPTION
When loading a saved conversation from the sidebar, the chat view now
automatically scrolls to the bottom so users see the most recent messages
instead of being stuck at the top.

https://claude.ai/code/session_01RuqjQrh8aCsDkAvi8xNup8