### PR TITLE
Upgrade rmcp 0.13 → 0.16 (#107)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6291,8 +6291,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437fa2a15825caf2505411bbe55b05c8eb122e03934938b38f9ecaa1d6ded7c8"
+source = "git+https://github.com/0xPlaygrounds/rig?branch=main#236276d393d42c0608d11e9aef56523e82c0f306"
 dependencies = [
  "as-any",
  "async-stream",
@@ -6366,9 +6365,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1815dbc06c414d720f8bc1951eccd66bc99efc6376331f1e7093a119b3eb508"
+checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6390,9 +6389,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f0bc7008fa102e771a76c6d2c9b253be3f2baa5964e060464d038ae1cbc573"
+checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 gpui = "0.2.2"
 gpui-component = "0.5.1"
 gpui-component-assets = "0.5.1"
-rig-core = "0.31.0"
-rmcp = { version = "0.13", features = ["client", "macros", "transport-child-process"] }
+rig-core = { git = "https://github.com/0xPlaygrounds/rig", branch = "main" }
+rmcp = { version = "0.16", features = ["client", "macros", "transport-child-process"] }
 nix = { version = "0.29", features = ["signal"] }
 
 # Persistence layer dependencies


### PR DESCRIPTION
## Summary
- Upgrade `rmcp` from `0.13` to `0.16.0`, adding OAuth2 auth, streamable HTTP transport, and Tower service integration
- Use `rig-core` from git main (pre-0.32.0) since published 0.31.0 still pins rmcp 0.13
- No code changes needed — all rmcp APIs used by Chatty are stable across versions

## Follow-up
Once `rig-core` 0.32.0 is published on crates.io ([release PR #1414](https://github.com/0xPlaygrounds/rig/pull/1414)), switch back to a version pin.

## Test plan
- [x] All 367 tests pass
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Formatting clean (`cargo fmt --check`)
- [x] Single rmcp version in dependency tree (no duplicates)

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)