### PR TITLE
Pre-allocate string buffers for streaming message content

### DIFF
--- a/src/chatty/models/conversation.rs
+++ b/src/chatty/models/conversation.rs
@@ -571,7 +571,9 @@ impl Conversation {
         if let Some(ref mut content) = self.streaming_message {
             content.push_str(text);
         } else {
-            self.streaming_message = Some(text.to_string());
+            let mut s = String::with_capacity(4096);
+            s.push_str(text);
+            self.streaming_message = Some(s);
         }
     }
 }

--- a/src/chatty/models/stream_manager.rs
+++ b/src/chatty/models/stream_manager.rs
@@ -152,7 +152,7 @@ impl StreamManager {
                 task: Some(task),
                 cancel_flag,
                 pending_artifacts,
-                pending_text: String::new(),
+                pending_text: String::with_capacity(4096),
                 last_flush: Instant::now(),
             },
         );
@@ -187,7 +187,7 @@ impl StreamManager {
                 task: Some(task),
                 cancel_flag,
                 pending_artifacts,
-                pending_text: String::new(),
+                pending_text: String::with_capacity(4096),
                 last_flush: Instant::now(),
             },
         );


### PR DESCRIPTION
## Summary
This PR optimizes string allocation performance for streaming message handling by pre-allocating buffers with a 4KB capacity instead of using default zero-capacity allocations.

## Key Changes
- **conversation.rs**: Modified `append_to_streaming_message()` to pre-allocate a `String` with 4096 bytes capacity before appending text, rather than assigning a freshly converted string
- **stream_manager.rs**: Updated two stream initialization locations to use `String::with_capacity(4096)` instead of `String::new()` for the `pending_text` field

## Implementation Details
These changes reduce the number of memory reallocations during streaming operations. Since streaming messages typically accumulate text incrementally, pre-allocating a reasonable buffer size (4KB) minimizes the overhead of repeated allocations as content grows. This is particularly beneficial for long-running streams where many small text chunks are appended sequentially.

https://claude.ai/code/session_0189pbsoTX2TgXJkYpJTyGyJ