### PR TITLE
Add visual diff view for apply_diff tool calls

### DIFF
--- a/src/chatty/views/chat_view.rs
+++ b/src/chatty/views/chat_view.rs
@@ -39,6 +39,8 @@ pub struct ChatView {
     pending_approval: Option<PendingApprovalInfo>,
     /// Tracks which tool calls are collapsed: (message_idx, tool_idx) -> collapsed
     collapsed_tool_calls: HashMap<(usize, usize), bool>,
+    /// Tracks which diff views are fully expanded: (message_idx, tool_idx) -> expanded
+    diff_expanded: HashMap<(usize, usize), bool>,
     /// Cache for parsed message content (markdown, math, code highlighting)
     parsed_cache: ParsedContentCache,
     /// Incremental streaming parse state, reusing stable content/markdown segments
@@ -106,6 +108,7 @@ impl ChatView {
             scroll_handle,
             pending_approval: None,
             collapsed_tool_calls: HashMap::new(),
+            diff_expanded: HashMap::new(),
             parsed_cache: ParsedContentCache::new(),
             streaming_parse_cache: None,
             stick_to_bottom: true,
@@ -862,6 +865,7 @@ impl ChatView {
 
         // Clear collapsed tool calls state from previous conversation
         self.collapsed_tool_calls.clear();
+        self.diff_expanded.clear();
 
         // Clear parsed content cache from previous conversation
         self.parsed_cache.clear();
@@ -1205,6 +1209,8 @@ impl Render for ChatView {
                                     .children({
                                         let collapsed_tool_calls =
                                             self.collapsed_tool_calls.clone();
+                                        let diff_expanded =
+                                            self.diff_expanded.clone();
                                         let chat_view_entity = cx.entity();
 
                                         // Temporarily move caches out to avoid split borrow
@@ -1247,6 +1253,7 @@ impl Render for ChatView {
                                             .into_iter()
                                             .map(|(index, msg)| {
                                                 let entity_clone = chat_view_entity.clone();
+                                                let entity_for_diff = chat_view_entity.clone();
                                                 let entity_for_feedback = chat_view_entity.clone();
                                                 let entity_for_regenerate = chat_view_entity.clone();
                                                 let history_index = msg.history_index;
@@ -1265,6 +1272,7 @@ impl Render for ChatView {
                                                     index,
                                                     is_last_message,
                                                     &collapsed_tool_calls,
+                                                    &diff_expanded,
                                                     &mut parsed_cache,
                                                     sc,
                                                     move |msg_idx, tool_idx, cx| {
@@ -1278,6 +1286,21 @@ impl Render for ChatView {
 
                                                             chat_view
                                                                 .collapsed_tool_calls
+                                                                .insert(key, !current);
+                                                            cx.notify();
+                                                        });
+                                                    },
+                                                    move |msg_idx, tool_idx, cx| {
+                                                        entity_for_diff.update(cx, |chat_view, cx| {
+                                                            let key = (msg_idx, tool_idx);
+                                                            let current = chat_view
+                                                                .diff_expanded
+                                                                .get(&key)
+                                                                .copied()
+                                                                .unwrap_or(false);
+
+                                                            chat_view
+                                                                .diff_expanded
                                                                 .insert(key, !current);
                                                             cx.notify();
                                                         });

--- a/src/chatty/views/diff_view_component.rs
+++ b/src/chatty/views/diff_view_component.rs
@@ -1,0 +1,353 @@
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::ActiveTheme;
+use similar::{ChangeTag, TextDiff};
+
+/// Callback type for mouse-down events (expand diff, etc.).
+type MouseDownCallback = Box<dyn Fn(&MouseDownEvent, &mut Window, &mut App) + 'static>;
+
+/// Maximum combined content size (bytes) before falling back to summary-only.
+const MAX_CONTENT_SIZE: usize = 100_000;
+
+/// Number of diff lines shown before the "Show more" expander kicks in.
+const PREVIEW_LINES: usize = 10;
+
+/// Number of equal (context) lines to show around each change hunk.
+const CONTEXT_LINES: usize = 3;
+
+/// A single diff line with its change tag and text.
+struct DiffLine {
+    tag: ChangeTag,
+    text: String,
+}
+
+/// A renderable item in the collapsed diff view.
+enum DiffItem {
+    Line(DiffLine),
+    CollapsedEqual(usize), // number of hidden equal lines
+}
+
+/// Visual diff view for `apply_diff` tool calls.
+///
+/// Shows line-by-line additions (green) and deletions (red) inline within the
+/// tool call accordion. Long runs of unchanged lines are collapsed with a
+/// separator. Large diffs are preview-capped with an expand button.
+#[derive(IntoElement)]
+pub struct DiffViewComponent {
+    old_content: String,
+    new_content: String,
+    file_path: String,
+    message_index: usize,
+    tool_index: usize,
+    is_fully_expanded: bool,
+    on_expand: Option<MouseDownCallback>,
+}
+
+impl DiffViewComponent {
+    pub fn new(
+        old_content: String,
+        new_content: String,
+        file_path: String,
+        message_index: usize,
+        tool_index: usize,
+        is_fully_expanded: bool,
+    ) -> Self {
+        Self {
+            old_content,
+            new_content,
+            file_path,
+            message_index,
+            tool_index,
+            is_fully_expanded,
+            on_expand: None,
+        }
+    }
+
+    pub fn on_expand(
+        mut self,
+        cb: impl Fn(&MouseDownEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_expand = Some(Box::new(cb));
+        self
+    }
+}
+
+/// Build the list of DiffItems, collapsing long runs of equal lines.
+fn build_diff_items(old: &str, new: &str) -> (Vec<DiffItem>, usize, usize) {
+    let diff = TextDiff::from_lines(old, new);
+    let raw_lines: Vec<DiffLine> = diff
+        .iter_all_changes()
+        .map(|change| DiffLine {
+            tag: change.tag(),
+            text: change.to_string_lossy().to_string(),
+        })
+        .collect();
+
+    let mut insertions: usize = 0;
+    let mut deletions: usize = 0;
+    for line in &raw_lines {
+        match line.tag {
+            ChangeTag::Insert => insertions += 1,
+            ChangeTag::Delete => deletions += 1,
+            ChangeTag::Equal => {}
+        }
+    }
+
+    // Mark which lines are "near" a change (within CONTEXT_LINES)
+    let len = raw_lines.len();
+    let mut near_change = vec![false; len];
+    for (i, line) in raw_lines.iter().enumerate() {
+        if line.tag != ChangeTag::Equal {
+            let start = i.saturating_sub(CONTEXT_LINES);
+            let end = (i + CONTEXT_LINES + 1).min(len);
+            for flag in near_change[start..end].iter_mut() {
+                *flag = true;
+            }
+        }
+    }
+
+    // Build items, collapsing runs of equal lines that are far from changes
+    let mut items = Vec::new();
+    let mut collapse_count: usize = 0;
+
+    for (i, line) in raw_lines.into_iter().enumerate() {
+        if line.tag == ChangeTag::Equal && !near_change[i] {
+            collapse_count += 1;
+        } else {
+            if collapse_count > 0 {
+                items.push(DiffItem::CollapsedEqual(collapse_count));
+                collapse_count = 0;
+            }
+            items.push(DiffItem::Line(line));
+        }
+    }
+    if collapse_count > 0 {
+        items.push(DiffItem::CollapsedEqual(collapse_count));
+    }
+
+    (items, insertions, deletions)
+}
+
+impl RenderOnce for DiffViewComponent {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let border_color = cx.theme().border;
+        let muted_bg = cx.theme().muted;
+        let muted_text = cx.theme().muted_foreground;
+        let _text_color = cx.theme().foreground;
+
+        let total_size = self.old_content.len() + self.new_content.len();
+
+        // Header: file path + stats
+        let (items, insertions, deletions) = if total_size <= MAX_CONTENT_SIZE {
+            build_diff_items(&self.old_content, &self.new_content)
+        } else {
+            (Vec::new(), 0, 0)
+        };
+
+        let stats_text = format!("+{insertions} \u{2212}{deletions}");
+
+        let header = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap_2()
+            .px_2()
+            .py_1()
+            .child(
+                div()
+                    .font_family("monospace")
+                    .text_xs()
+                    .text_color(muted_text)
+                    .child(self.file_path.clone()),
+            )
+            .child(
+                div().text_xs().px_1().rounded_sm().bg(muted_bg).child(
+                    div()
+                        .flex()
+                        .flex_row()
+                        .gap_1()
+                        .child(
+                            div()
+                                .text_color(gpui::green())
+                                .child(format!("+{insertions}")),
+                        )
+                        .child(
+                            div()
+                                .text_color(cx.theme().ring)
+                                .child(format!("\u{2212}{deletions}")),
+                        ),
+                ),
+            );
+
+        // If content is too large, show summary only
+        if total_size > MAX_CONTENT_SIZE {
+            return div()
+                .flex()
+                .flex_col()
+                .border_1()
+                .border_color(border_color)
+                .rounded_md()
+                .overflow_hidden()
+                .child(header)
+                .child(
+                    div()
+                        .px_2()
+                        .py_1()
+                        .text_xs()
+                        .text_color(muted_text)
+                        .font_family("monospace")
+                        .child(format!("Diff too large to display ({} bytes)", total_size)),
+                )
+                .into_any_element();
+        }
+
+        // Count renderable lines (each DiffItem::Line counts as 1, CollapsedEqual as 1)
+        let total_items = items.len();
+        let should_truncate = !self.is_fully_expanded && total_items > PREVIEW_LINES;
+        let visible_count = if should_truncate {
+            PREVIEW_LINES
+        } else {
+            total_items
+        };
+
+        let insert_bg = gpui::green().opacity(0.12);
+        let delete_bg = cx.theme().ring.opacity(0.12);
+        let insert_text = gpui::green();
+        let delete_text = cx.theme().ring;
+
+        // Render visible diff lines
+        let line_elements: Vec<AnyElement> = items
+            .iter()
+            .take(visible_count)
+            .enumerate()
+            .map(|(i, item)| match item {
+                DiffItem::Line(line) => {
+                    let (bg, prefix, line_color) = match line.tag {
+                        ChangeTag::Insert => (insert_bg, "+", insert_text),
+                        ChangeTag::Delete => (delete_bg, "-", delete_text),
+                        ChangeTag::Equal => (gpui::transparent_black(), " ", muted_text),
+                    };
+
+                    // Strip trailing newline for display
+                    let display_text = line.text.trim_end_matches('\n').to_string();
+
+                    div()
+                        .id(ElementId::Name(
+                            format!(
+                                "diff-line-{}-{}-{}",
+                                self.message_index, self.tool_index, i
+                            )
+                            .into(),
+                        ))
+                        .flex()
+                        .flex_row()
+                        .w_full()
+                        .bg(bg)
+                        .font_family("monospace")
+                        .text_xs()
+                        .line_height(relative(1.6))
+                        .child(
+                            div()
+                                .w(px(16.0))
+                                .flex_shrink_0()
+                                .text_color(line_color)
+                                .text_center()
+                                .child(prefix),
+                        )
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .text_color(line_color)
+                                .child(display_text),
+                        )
+                        .into_any_element()
+                }
+                DiffItem::CollapsedEqual(count) => div()
+                    .id(ElementId::Name(
+                        format!(
+                            "diff-collapse-{}-{}-{}",
+                            self.message_index, self.tool_index, i
+                        )
+                        .into(),
+                    ))
+                    .w_full()
+                    .text_center()
+                    .text_xs()
+                    .text_color(muted_text)
+                    .py(px(2.0))
+                    .font_family("monospace")
+                    .child(format!(
+                        "\u{00b7}\u{00b7}\u{00b7} {count} unchanged line{} \u{00b7}\u{00b7}\u{00b7}",
+                        if *count == 1 { "" } else { "s" }
+                    ))
+                    .into_any_element(),
+            })
+            .collect();
+
+        let mut container = div()
+            .flex()
+            .flex_col()
+            .border_1()
+            .border_color(border_color)
+            .rounded_md()
+            .overflow_hidden()
+            .child(header)
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .px_1()
+                    .py_1()
+                    .children(line_elements),
+            );
+
+        // "Show N more lines" expander
+        if should_truncate {
+            let remaining = total_items - PREVIEW_LINES;
+            let expander = div()
+                .id(ElementId::Name(
+                    format!("diff-expand-{}-{}", self.message_index, self.tool_index).into(),
+                ))
+                .w_full()
+                .text_center()
+                .cursor_pointer()
+                .py_1()
+                .bg(muted_bg.opacity(0.5))
+                .border_t_1()
+                .border_color(border_color)
+                .text_xs()
+                .text_color(cx.theme().primary)
+                .font_weight(FontWeight::MEDIUM)
+                .child(format!(
+                    "\u{25b6} Show {remaining} more line{}",
+                    if remaining == 1 { "" } else { "s" }
+                ))
+                .when_some(
+                    self.on_expand,
+                    |this: Stateful<Div>, cb: MouseDownCallback| {
+                        this.on_mouse_down(MouseButton::Left, move |event, window, cx| {
+                            cb(event, window, cx);
+                        })
+                    },
+                );
+
+            container = container.child(expander);
+        }
+
+        // Also show the raw stats line from the tool output
+        container = container.child(
+            div()
+                .px_2()
+                .py(px(2.0))
+                .border_t_1()
+                .border_color(border_color)
+                .text_xs()
+                .text_color(muted_text)
+                .font_family("monospace")
+                .child(stats_text),
+        );
+
+        container.into_any_element()
+    }
+}

--- a/src/chatty/views/message_component.rs
+++ b/src/chatty/views/message_component.rs
@@ -920,18 +920,21 @@ fn render_text_segment_cached(
 
 /// Render interleaved content: text segments mixed with tool calls
 #[allow(clippy::too_many_arguments)]
-fn render_interleaved_content<F>(
+fn render_interleaved_content<F, D>(
     msg: &DisplayMessage,
     index: usize,
     mut container: Div,
     collapsed_tool_calls: &std::collections::HashMap<(usize, usize), bool>,
+    diff_expanded: &std::collections::HashMap<(usize, usize), bool>,
     parsed_cache: &mut ParsedContentCache,
     streaming_cache: &mut Option<StreamingParseState>,
     on_toggle_tool: F,
+    on_toggle_diff: D,
     cx: &App,
 ) -> Div
 where
     F: Fn(usize, usize, &mut App) + 'static + Clone,
+    D: Fn(usize, usize, &mut App) + 'static + Clone,
 {
     use super::message_types::TraceItem;
 
@@ -1009,6 +1012,17 @@ where
                     on_toggle_clone(msg_idx, tool_idx, cx);
                 };
 
+            let is_diff_expanded = diff_expanded
+                .get(&(index, tool_idx))
+                .copied()
+                .unwrap_or(false);
+
+            let on_diff_clone = on_toggle_diff.clone();
+            let diff_callback =
+                move |_event: &MouseDownEvent, _window: &mut Window, cx: &mut App| {
+                    on_diff_clone(msg_idx, tool_idx, cx);
+                };
+
             container = container.child(div().mt_2().mb_2().child(
                 super::trace_components::render_tool_call_inline(
                     tool_call,
@@ -1016,6 +1030,8 @@ where
                     tool_idx,
                     is_collapsed,
                     toggle_callback,
+                    is_diff_expanded,
+                    diff_callback,
                     cx,
                 ),
             ));
@@ -1176,20 +1192,23 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn render_message<F, G, R>(
+pub fn render_message<F, D, G, R>(
     msg: &DisplayMessage,
     index: usize,
     is_last_message: bool,
     collapsed_tool_calls: &std::collections::HashMap<(usize, usize), bool>,
+    diff_expanded: &std::collections::HashMap<(usize, usize), bool>,
     parsed_cache: &mut ParsedContentCache,
     streaming_cache: &mut Option<StreamingParseState>,
     on_toggle_tool: F,
+    on_toggle_diff: D,
     on_feedback: G,
     on_regenerate: R,
     cx: &App,
 ) -> AnyElement
 where
     F: Fn(usize, usize, &mut App) + 'static + Clone,
+    D: Fn(usize, usize, &mut App) + 'static + Clone,
     G: Fn(usize, Option<MessageFeedback>, &mut App) + 'static + Clone,
     R: Fn(usize, &mut App) + 'static + Clone,
 {
@@ -1285,9 +1304,11 @@ where
             index,
             container,
             collapsed_tool_calls,
+            diff_expanded,
             parsed_cache,
             streaming_cache,
             on_toggle_tool,
+            on_toggle_diff,
             cx,
         )
     } else if msg.is_markdown {

--- a/src/chatty/views/mod.rs
+++ b/src/chatty/views/mod.rs
@@ -5,6 +5,7 @@ pub mod chat_input;
 pub mod chat_view;
 pub mod code_block_component;
 pub mod conversation_item;
+pub mod diff_view_component;
 pub mod error_log_dialog;
 pub mod footer;
 pub mod math_parser;

--- a/src/chatty/views/trace_components.rs
+++ b/src/chatty/views/trace_components.rs
@@ -6,6 +6,7 @@ use gpui::{prelude::FluentBuilder, *};
 use gpui_component::{ActiveTheme, Icon, Sizable, button::Button, text::TextView};
 use std::time::Duration;
 
+use super::diff_view_component::DiffViewComponent;
 use super::message_types::{
     ApprovalState, SystemTrace, ThinkingBlock, ToolCallBlock, ToolCallState, TraceEvent, TraceItem,
 };
@@ -692,16 +693,20 @@ impl Render for SystemTraceView {
 }
 
 /// Public function to render a single tool call inline (for interleaved content)
-pub fn render_tool_call_inline<F>(
+#[allow(clippy::too_many_arguments)]
+pub fn render_tool_call_inline<F, D>(
     tool_call: &ToolCallBlock,
     message_index: usize,
     tool_index: usize,
     collapsed: bool,
     on_toggle: F,
+    diff_expanded: bool,
+    on_expand_diff: D,
     cx: &App,
 ) -> impl IntoElement
 where
     F: Fn(&MouseDownEvent, &mut Window, &mut App) + 'static,
+    D: Fn(&MouseDownEvent, &mut Window, &mut App) + 'static,
 {
     use tracing::debug;
 
@@ -809,40 +814,62 @@ where
         content_children.push(render_full_command_box(full_command, panel_bg, text_color));
     }
 
-    // Add output section if available
-    if let Some(output) = tool_call
-        .output
-        .as_ref()
-        .or(tool_call.output_preview.as_ref())
+    // For apply_diff tool calls with success, render a visual diff view
+    let has_diff_view = if tool_call.tool_name == "apply_diff"
+        && matches!(tool_call.state, ToolCallState::Success)
     {
-        let formatted_output = format_tool_output(output);
-        content_children.push(
-            div()
-                .font_family("monospace")
-                .text_xs()
-                .px_2()
-                .py_1()
-                .bg(panel_bg)
-                .rounded_sm()
-                .text_color(text_color)
-                .child(SelectableText::new(
-                    ElementId::Name(
-                        format!("inline-tool-output-{}-{}", message_index, tool_index).into(),
-                    ),
-                    formatted_output,
-                ))
-                .into_any_element(),
-        );
-    } else if matches!(tool_call.state, ToolCallState::Running) {
-        // Show "Running..." for running tools
-        content_children.push(
-            div()
-                .font_family("monospace")
-                .text_xs()
-                .text_color(muted_text)
-                .child("Running...")
-                .into_any_element(),
-        );
+        if let Some(diff_view) = try_build_diff_view(
+            &tool_call.input,
+            message_index,
+            tool_index,
+            diff_expanded,
+            on_expand_diff,
+        ) {
+            content_children.push(diff_view);
+            true
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    // Add output section if available (skip for apply_diff with diff view)
+    if !has_diff_view {
+        if let Some(output) = tool_call
+            .output
+            .as_ref()
+            .or(tool_call.output_preview.as_ref())
+        {
+            let formatted_output = format_tool_output(output);
+            content_children.push(
+                div()
+                    .font_family("monospace")
+                    .text_xs()
+                    .px_2()
+                    .py_1()
+                    .bg(panel_bg)
+                    .rounded_sm()
+                    .text_color(text_color)
+                    .child(SelectableText::new(
+                        ElementId::Name(
+                            format!("inline-tool-output-{}-{}", message_index, tool_index).into(),
+                        ),
+                        formatted_output,
+                    ))
+                    .into_any_element(),
+            );
+        } else if matches!(tool_call.state, ToolCallState::Running) {
+            // Show "Running..." for running tools
+            content_children.push(
+                div()
+                    .font_family("monospace")
+                    .text_xs()
+                    .text_color(muted_text)
+                    .child("Running...")
+                    .into_any_element(),
+            );
+        }
     }
 
     // Add error section if error state
@@ -906,6 +933,38 @@ where
                     .children(content_children),
             )
         })
+}
+
+/// Try to build a diff view from apply_diff tool input JSON.
+/// Returns None if parsing fails.
+fn try_build_diff_view(
+    input_json: &str,
+    message_index: usize,
+    tool_index: usize,
+    diff_expanded: bool,
+    on_expand_diff: impl Fn(&MouseDownEvent, &mut Window, &mut App) + 'static,
+) -> Option<AnyElement> {
+    #[derive(serde::Deserialize)]
+    struct ApplyDiffInput {
+        path: String,
+        old_content: String,
+        new_content: String,
+    }
+
+    let args: ApplyDiffInput = serde_json::from_str(input_json).ok()?;
+
+    Some(
+        DiffViewComponent::new(
+            args.old_content,
+            args.new_content,
+            args.path,
+            message_index,
+            tool_index,
+            diff_expanded,
+        )
+        .on_expand(on_expand_diff)
+        .into_any_element(),
+    )
 }
 
 /// Render the full command text box (used when the header was truncated)


### PR DESCRIPTION
When the LLM uses the apply_diff tool, the tool trace now shows a line-by-line diff view instead of raw JSON output. Additions are shown in green, deletions in red, with context lines around each change hunk. Long runs of unchanged lines are collapsed with a separator. Large diffs show only a preview (first 10 lines) with an expandable "Show N more lines" button. Content over 100KB falls back to a summary.

New file: diff_view_component.rs (DiffViewComponent, RenderOnce)
Modified: trace_components.rs (detect apply_diff, render diff view)
Modified: chat_view.rs (diff_expanded state tracking)
Modified: message_component.rs (thread diff state through rendering)
Modified: mod.rs (register new module)

https://claude.ai/code/session_01XtvEhoXCjCFd2n5V2PWEkw