### PR TITLE
Fix Windows release build: gpui crate does not support Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,8 +215,12 @@ jobs:
           restore-keys: |
             cargo-release-${{ runner.os }}-
 
-      - name: Build release binary
-        run: cargo build --release
+      - name: Build release binary (TUI only — gpui does not support Windows)
+        run: cargo build --release -p chatty-tui
+
+      - name: Copy chatty-tui.exe as chatty.exe for installer
+        run: copy target\release\chatty-tui.exe target\release\chatty.exe
+        shell: cmd
 
       - name: Install Inno Setup
         run: choco install innosetup -y


### PR DESCRIPTION
Build only chatty-tui on Windows and copy the binary as chatty.exe
so the Inno Setup installer can package it under the expected name.

https://claude.ai/code/session_016JBzzuA9mvDKK9Xcyutxex