### PR TITLE
Fix Azure OpenAI reasoning model errors (gpt-5-mini, o-series)

### DIFF
--- a/crates/chatty-core/src/factories/agent_factory.rs
+++ b/crates/chatty-core/src/factories/agent_factory.rs
@@ -1363,10 +1363,12 @@ impl AgentClient {
                 }
 
                 if is_reasoning_model || !model_config.supports_temperature {
+                    // Azure uses the Chat Completions API (not the Responses API),
+                    // so reasoning config is a top-level `reasoning_effort` param
+                    // instead of the nested `reasoning.summary` used by OpenAI's
+                    // Responses API.
                     builder = builder.additional_params(serde_json::json!({
-                        "reasoning": {
-                            "summary": "auto"
-                        }
+                        "reasoning_effort": "medium"
                     }));
                 }
 

--- a/crates/chatty-core/src/settings/models/models_store.rs
+++ b/crates/chatty-core/src/settings/models/models_store.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use super::providers_store::ProviderType;
 
 /// Default API version for Azure OpenAI
-pub const AZURE_DEFAULT_API_VERSION: &str = "2024-10-21";
+pub const AZURE_DEFAULT_API_VERSION: &str = "2025-03-01-preview";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ModelConfig {


### PR DESCRIPTION
Azure OpenAI uses the Chat Completions API, not the Responses API.
The `reasoning.summary` parameter is only valid for the Responses API
and causes errors when sent to Azure's Chat Completions endpoint.

Replace with `reasoning_effort` (the Chat Completions API equivalent)
and update the default API version from 2024-10-21 to 2025-03-01-preview
which adds reasoning model support.

https://claude.ai/code/session_01HP6WQwsivu8VBS7xF9hAdd