### PR TITLE
Fix Docker connection error by adding fallback socket discovery

### DIFF
--- a/crates/chatty-core/src/factories/agent_factory.rs
+++ b/crates/chatty-core/src/factories/agent_factory.rs
@@ -784,6 +784,7 @@ impl AgentClient {
                     .map(|s| s.network_isolation)
                     .unwrap_or(true),
                 workspace_path: exec_settings.as_ref().and_then(|s| s.workspace_dir.clone()),
+                docker_host: exec_settings.as_ref().and_then(|s| s.docker_host.clone()),
                 ..SandboxConfig::default()
             };
             let manager = std::sync::Arc::new(SandboxManager::new(sandbox_config));

--- a/crates/chatty-core/src/sandbox/backend.rs
+++ b/crates/chatty-core/src/sandbox/backend.rs
@@ -31,6 +31,8 @@ pub struct SandboxConfig {
     pub workspace_path: Option<String>,
     /// Container ports to publish to the host (default: empty = no ports published)
     pub expose_ports: Vec<u16>,
+    /// Custom Docker host URI or socket path. When None, fallback discovery is used.
+    pub docker_host: Option<String>,
 }
 
 impl Default for SandboxConfig {
@@ -43,6 +45,7 @@ impl Default for SandboxConfig {
             network: false,
             workspace_path: None,
             expose_ports: vec![],
+            docker_host: None,
         }
     }
 }
@@ -123,7 +126,7 @@ pub trait SandboxBackend: Send + Sync {
 
     /// Health check — is the backend available?
     #[allow(dead_code)]
-    async fn is_available() -> Result<bool>
+    async fn is_available(docker_host: Option<&str>) -> Result<bool>
     where
         Self: Sized;
 }

--- a/crates/chatty-core/src/sandbox/docker.rs
+++ b/crates/chatty-core/src/sandbox/docker.rs
@@ -10,11 +10,94 @@ use bollard::image::CreateImageOptions;
 use bollard::models::{HostConfig, PortBinding};
 use futures::StreamExt;
 use std::collections::HashMap;
+use std::path::Path;
 use std::time::Duration;
 use tokio::time::timeout;
+use tracing::debug;
 use uuid::Uuid;
 
 use super::backend::{ExecutionResult, Language, SandboxBackend, SandboxConfig};
+
+/// Build a list of common Docker socket paths to try as fallbacks.
+fn fallback_socket_paths() -> Vec<String> {
+    let mut paths = Vec::new();
+
+    // XDG_RUNTIME_DIR/docker.sock (rootless Docker on Linux)
+    if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+        paths.push(format!("{}/docker.sock", xdg));
+    }
+
+    // Docker Desktop and other common paths
+    if let Ok(home) = std::env::var("HOME") {
+        paths.push(format!("{}/.docker/run/docker.sock", home));
+        paths.push(format!("{}/.docker/desktop/docker.sock", home));
+    }
+
+    paths
+}
+
+/// Try to connect to a Docker daemon at a specific socket path and verify with ping.
+async fn try_socket(path: &str) -> Result<Docker, String> {
+    let docker = Docker::connect_with_socket(path, 120, bollard::API_DEFAULT_VERSION)
+        .map_err(|e| format!("connect failed: {}", e))?;
+    docker
+        .ping()
+        .await
+        .map_err(|e| format!("ping failed: {}", e))?;
+    Ok(docker)
+}
+
+/// Connect to Docker, trying multiple strategies:
+/// 1. If `docker_host` is Some, use that explicitly
+/// 2. Try Bollard's `connect_with_local_defaults()` (checks DOCKER_HOST env + platform default)
+/// 3. Try common fallback socket paths (rootless Docker, Docker Desktop, etc.)
+async fn connect_docker(docker_host: Option<&str>) -> Result<Docker> {
+    // Strategy 1: User-configured docker host
+    if let Some(host) = docker_host {
+        let path = host.strip_prefix("unix://").unwrap_or(host);
+        return try_socket(path).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Cannot connect to Docker at configured host '{}': {}",
+                host,
+                e
+            )
+        });
+    }
+
+    // Strategy 2: Bollard defaults (DOCKER_HOST env + /var/run/docker.sock)
+    if let Ok(docker) = Docker::connect_with_local_defaults()
+        && docker.ping().await.is_ok()
+    {
+        return Ok(docker);
+    }
+    debug!("Docker connect_with_local_defaults failed, trying fallback socket paths");
+
+    // Strategy 3: Try common fallback socket paths
+    let fallbacks = fallback_socket_paths();
+    let mut tried = vec!["default (/var/run/docker.sock or DOCKER_HOST)".to_string()];
+
+    for path in &fallbacks {
+        if !Path::new(path).exists() {
+            tried.push(format!("{} (not found)", path));
+            continue;
+        }
+        match try_socket(path).await {
+            Ok(docker) => {
+                debug!(path, "Connected to Docker via fallback socket");
+                return Ok(docker);
+            }
+            Err(e) => {
+                tried.push(format!("{} ({})", path, e));
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "Cannot connect to Docker. Tried:\n  - {}\n\
+         Tip: Set \"Docker Host\" in Settings → Execution to specify the socket path.",
+        tried.join("\n  - ")
+    )
+}
 
 /// Docker-based sandbox using bollard to manage containers.
 pub struct DockerSandbox {
@@ -28,8 +111,7 @@ pub struct DockerSandbox {
 impl DockerSandbox {
     /// Create a new Docker sandbox container with the given configuration.
     pub async fn create(config: SandboxConfig) -> Result<Self> {
-        let docker = Docker::connect_with_local_defaults()
-            .context("Cannot connect to Docker. Is Docker Desktop running?")?;
+        let docker = connect_docker(config.docker_host.as_deref()).await?;
 
         Self::ensure_image(&docker, config.language.docker_image()).await?;
 
@@ -317,10 +399,7 @@ impl SandboxBackend for DockerSandbox {
         self.config.expose_ports.contains(&port)
     }
 
-    async fn is_available() -> Result<bool> {
-        match Docker::connect_with_local_defaults() {
-            Ok(docker) => Ok(docker.ping().await.is_ok()),
-            Err(_) => Ok(false),
-        }
+    async fn is_available(docker_host: Option<&str>) -> Result<bool> {
+        Ok(connect_docker(docker_host).await.is_ok())
     }
 }

--- a/crates/chatty-core/src/sandbox/manager.rs
+++ b/crates/chatty-core/src/sandbox/manager.rs
@@ -73,7 +73,9 @@ impl SandboxManager {
 
     /// Check if Docker is available on this system.
     #[allow(dead_code)]
-    pub async fn is_docker_available() -> bool {
-        DockerSandbox::is_available().await.unwrap_or(false)
+    pub async fn is_docker_available(docker_host: Option<&str>) -> bool {
+        DockerSandbox::is_available(docker_host)
+            .await
+            .unwrap_or(false)
     }
 }

--- a/crates/chatty-core/src/settings/models/execution_settings.rs
+++ b/crates/chatty-core/src/settings/models/execution_settings.rs
@@ -44,6 +44,10 @@ pub struct ExecutionSettingsModel {
     /// Requires Docker to be installed and running on the host.
     #[serde(default)]
     pub docker_code_execution_enabled: bool,
+    /// Custom Docker host URI or socket path (e.g., "/run/user/1000/docker.sock"
+    /// or "unix:///path/to/docker.sock"). When None, the app tries common default locations.
+    #[serde(default)]
+    pub docker_host: Option<String>,
     /// Maximum execution time in seconds
     pub timeout_seconds: u32,
     /// Maximum output size in bytes (prevents memory exhaustion)
@@ -75,6 +79,7 @@ impl Default for ExecutionSettingsModel {
             fetch_enabled: true, // Enabled by default for zero-config web access
             git_enabled: false,  // Opt-in: requires workspace with git repo
             docker_code_execution_enabled: false, // Opt-in: requires Docker
+            docker_host: None,
             timeout_seconds: 30,
             max_output_bytes: 51200, // 50KB
             network_isolation: false,

--- a/crates/chatty-gpui/src/cli_installer.rs
+++ b/crates/chatty-gpui/src/cli_installer.rs
@@ -142,7 +142,9 @@ async fn do_install() -> Result<String, String> {
 
     // Check if ~/.local/bin is in PATH
     let path_var = std::env::var("PATH").unwrap_or_default();
-    let in_path = path_var.split(':').any(|p| bin_dir == std::path::Path::new(p));
+    let in_path = path_var
+        .split(':')
+        .any(|p| bin_dir == std::path::Path::new(p));
 
     if in_path {
         Ok(format!(

--- a/crates/chatty-gpui/src/settings/controllers/execution_settings_controller.rs
+++ b/crates/chatty-gpui/src/settings/controllers/execution_settings_controller.rs
@@ -205,6 +205,30 @@ pub fn toggle_fetch(cx: &mut App) {
     .detach();
 }
 
+/// Update the Docker host setting and persist to disk.
+pub fn set_docker_host(host: Option<String>, cx: &mut App) {
+    // 1. Apply update immediately
+    cx.global_mut::<ExecutionSettingsModel>().docker_host = host;
+
+    // 2. Get updated state for async save
+    let settings = cx.global::<ExecutionSettingsModel>().clone();
+
+    // 3. Refresh UI immediately
+    cx.refresh_windows();
+
+    // 4. Notify so the active conversation's agent is rebuilt with the new docker host
+    notify_tool_set_changed(cx);
+
+    // 5. Save async with error handling
+    cx.spawn(|_cx: &mut AsyncApp| async move {
+        let repo = chatty_core::execution_settings_repository();
+        if let Err(e) = repo.save(settings).await {
+            error!(error = ?e, "Failed to save execution settings");
+        }
+    })
+    .detach();
+}
+
 /// Toggle Docker code execution enabled/disabled and persist to disk.
 pub fn toggle_docker_code_execution(cx: &mut App) {
     // 1. Apply update immediately (optimistic update)

--- a/crates/chatty-gpui/src/settings/views/execution_settings_page.rs
+++ b/crates/chatty-gpui/src/settings/views/execution_settings_page.rs
@@ -90,6 +90,30 @@ pub fn execution_settings_page() -> SettingPage {
                          TypeScript, Rust, and Bash. Requires Docker to be installed and running.",
                     ),
                     SettingItem::new(
+                        "Docker Host",
+                        SettingField::input(
+                            |cx: &App| {
+                                cx.global::<ExecutionSettingsModel>()
+                                    .docker_host
+                                    .clone()
+                                    .unwrap_or_default()
+                                    .into()
+                            },
+                            |val: SharedString, cx: &mut App| {
+                                let docker_host = if val.is_empty() {
+                                    None
+                                } else {
+                                    Some(val.to_string())
+                                };
+                                execution_settings_controller::set_docker_host(docker_host, cx);
+                            },
+                        ),
+                    )
+                    .description(
+                        "Custom Docker socket path or URI (e.g., /run/user/1000/docker.sock). \
+                         Leave empty to auto-detect common locations.",
+                    ),
+                    SettingItem::new(
                         "Approval Mode",
                         SettingField::render(|_options, _window, cx| {
                             let current_mode = cx.global::<ExecutionSettingsModel>().approval_mode.clone();


### PR DESCRIPTION
When Docker is available but not at the default socket path (e.g.,
rootless Docker, Docker Desktop on macOS/Linux), the app now tries
multiple common socket locations before giving up. Also adds a
"Docker Host" setting in Settings → Execution for manual override.

Fallback paths tried: XDG_RUNTIME_DIR/docker.sock, ~/.docker/run/docker.sock,
~/.docker/desktop/docker.sock. Error messages now list all paths attempted.

https://claude.ai/code/session_01N71bMVcWLTNyD7rYijRuck