### PR TITLE
Fix pdfium library not found on macOS despite bundled dylib

### DIFF
--- a/crates/chatty-core/src/services/pdf_thumbnail.rs
+++ b/crates/chatty-core/src/services/pdf_thumbnail.rs
@@ -2,6 +2,8 @@ use pdfium_render::prelude::*;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+use super::pdfium_utils::create_pdfium;
+
 const THUMBNAIL_SIZE: u32 = 64;
 
 lazy_static::lazy_static! {
@@ -42,12 +44,6 @@ impl From<image::ImageError> for PdfThumbnailError {
     fn from(err: image::ImageError) -> Self {
         PdfThumbnailError::Image(format!("{:?}", err))
     }
-}
-
-/// Get the path to the pdfium library set by build.rs
-fn pdfium_lib_path() -> Option<PathBuf> {
-    let lib_dir = option_env!("PDFIUM_LIB_DIR")?;
-    Some(PathBuf::from(lib_dir))
 }
 
 /// Get or create the session temp directory for PDF thumbnails
@@ -92,17 +88,8 @@ pub fn cleanup_thumbnails() {
 
 /// Render PDF first page to a temporary thumbnail PNG file
 pub fn render_pdf_thumbnail(pdf_path: &Path) -> Result<PathBuf, PdfThumbnailError> {
-    let lib_dir = pdfium_lib_path().ok_or_else(|| {
-        PdfThumbnailError::Pdfium("PDFIUM_LIB_DIR not set by build.rs".to_string())
-    })?;
-
-    // Construct full library path directly (avoids issues with special chars in path)
-    let lib_path = lib_dir.join(Pdfium::pdfium_platform_library_name());
-    let bindings = Pdfium::bind_to_library(&lib_path)
-        .or_else(|_| Pdfium::bind_to_system_library())
-        .map_err(|e| PdfThumbnailError::Pdfium(format!("Failed to bind pdfium: {:?}", e)))?;
-
-    let pdfium = Pdfium::new(bindings);
+    let pdfium = create_pdfium()
+        .map_err(|e| PdfThumbnailError::Pdfium(format!("Failed to bind pdfium: {}", e)))?;
 
     let document = pdfium.load_pdf_from_file(pdf_path, None)?;
     let page = document.pages().get(0)?;

--- a/crates/chatty-core/src/services/pdfium_utils.rs
+++ b/crates/chatty-core/src/services/pdfium_utils.rs
@@ -1,5 +1,6 @@
 use pdfium_render::prelude::*;
 use std::path::PathBuf;
+use tracing::{debug, info, warn};
 
 /// Get the path to the pdfium library directory set by build.rs (compile-time path).
 fn compile_time_lib_path() -> Option<PathBuf> {
@@ -13,30 +14,77 @@ fn compile_time_lib_path() -> Option<PathBuf> {
 /// - **macOS** `.app` bundle: `<exe>/../../Frameworks/` (`Contents/MacOS/../Frameworks/`)
 /// - **Linux** AppImage: `<exe>/../lib/` (`usr/bin/../lib/`)
 /// - **Windows** package: `<exe>/` (DLL next to the executable)
+///
+/// On macOS, `current_exe()` may return a symlinked or app-translocated path.
+/// We canonicalize before resolving `../Frameworks` so that `is_dir()` works
+/// correctly through symlinks.
 fn exe_relative_lib_path() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
-    let exe_dir = exe.parent()?;
+    debug!(path = %exe.display(), "pdfium: raw executable path");
+
+    // Canonicalize to resolve symlinks and translocation (especially on macOS)
+    let canonical_exe = std::fs::canonicalize(&exe)
+        .inspect_err(|e| warn!(error = %e, "pdfium: failed to canonicalize exe path"))
+        .ok();
+
+    if let Some(ref canon) = canonical_exe {
+        debug!(path = %canon.display(), "pdfium: canonical executable path");
+    }
 
     if cfg!(target_os = "macos") {
         // Contents/MacOS/<exe> → Contents/Frameworks/
-        let frameworks = exe_dir.join("../Frameworks");
-        if frameworks.is_dir() {
-            return Some(frameworks);
+        // Try canonical path first (handles symlinks/translocation)
+        if let Some(ref canon) = canonical_exe
+            && let Some(exe_dir) = canon.parent()
+        {
+            let frameworks = exe_dir.join("../Frameworks");
+            debug!(path = %frameworks.display(), "pdfium: trying canonical Frameworks path");
+            if frameworks.is_dir() {
+                return Some(frameworks);
+            }
+        }
+        // Fallback: raw (non-canonical) path
+        if let Some(exe_dir) = exe.parent() {
+            let frameworks = exe_dir.join("../Frameworks");
+            debug!(path = %frameworks.display(), "pdfium: trying raw Frameworks path");
+            if frameworks.is_dir() {
+                return Some(frameworks);
+            }
         }
     }
 
     if cfg!(target_os = "windows") {
         // Windows: pdfium.dll lives next to the executable
-        return Some(exe_dir.to_path_buf());
+        let exe_dir = canonical_exe
+            .as_ref()
+            .unwrap_or(&exe)
+            .parent()?
+            .to_path_buf();
+        return Some(exe_dir);
     }
 
     // Linux AppImage: usr/bin/<exe> → usr/lib/
-    // Also works as a generic fallback for other layouts
-    let lib_dir = exe_dir.join("../lib");
-    if lib_dir.is_dir() {
-        return Some(lib_dir);
+    let exe_for_linux = canonical_exe.as_ref().unwrap_or(&exe);
+    if let Some(exe_dir) = exe_for_linux.parent() {
+        let lib_dir = exe_dir.join("../lib");
+        debug!(path = %lib_dir.display(), "pdfium: trying exe-relative lib path");
+        if lib_dir.is_dir() {
+            return Some(lib_dir);
+        }
     }
 
+    // Final fallback: library next to the executable (non-standard installations)
+    let exe_for_fallback = canonical_exe.as_ref().unwrap_or(&exe);
+    if let Some(exe_dir) = exe_for_fallback.parent() {
+        let lib_name = Pdfium::pdfium_platform_library_name();
+        let beside_exe = exe_dir.join(&lib_name);
+        debug!(path = %beside_exe.display(), "pdfium: trying library beside executable");
+        if beside_exe.exists() {
+            return Some(exe_dir.to_path_buf());
+        }
+    }
+
+    debug!("pdfium: no exe-relative library path found");
     None
 }
 
@@ -54,16 +102,32 @@ pub fn create_pdfium() -> anyhow::Result<Pdfium> {
     let mut last_err = None;
     for dir in candidate_dirs.into_iter().flatten() {
         let lib_path = dir.join(&lib_name);
+        debug!(path = %lib_path.display(), "pdfium: trying candidate library");
         match Pdfium::bind_to_library(&lib_path) {
-            Ok(bindings) => return Ok(Pdfium::new(bindings)),
-            Err(e) => last_err = Some(e),
+            Ok(bindings) => {
+                info!(path = %lib_path.display(), "pdfium: successfully bound library");
+                return Ok(Pdfium::new(bindings));
+            }
+            Err(e) => {
+                debug!(path = %lib_path.display(), error = ?e, "pdfium: candidate failed");
+                last_err = Some(e);
+            }
         }
     }
 
     // Final fallback: system library
+    debug!("pdfium: trying system library fallback");
     Pdfium::bind_to_system_library()
-        .map(Pdfium::new)
+        .map(|bindings| {
+            info!("pdfium: successfully bound system library");
+            Pdfium::new(bindings)
+        })
         .map_err(|e| {
+            warn!(
+                last_candidate_error = ?last_err,
+                system_error = ?e,
+                "pdfium: all binding attempts failed"
+            );
             anyhow::anyhow!(
                 "Failed to bind pdfium (last candidate error: {:?}, system error: {:?})",
                 last_err,


### PR DESCRIPTION
The v0.1.89 fix added exe-relative path resolution but
std::env::current_exe() on macOS can return symlinked or
app-translocated paths where ../Frameworks doesn't resolve
correctly via is_dir().

Changes:
- pdfium_utils.rs: canonicalize exe path before resolving
  ../Frameworks, try both canonical and raw paths, add
  beside-exe fallback, add tracing for all path attempts
- pdf_thumbnail.rs: replace duplicate loading logic with
  shared create_pdfium() so all PDF features use the same
  robust path resolution

https://claude.ai/code/session_01B8EDsoHymNnwGETQXejUzw