### PR TITLE
Fix Windows CI: enable duckdb bundled only on non-Windows platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,7 +1567,6 @@ dependencies = [
  "chrono",
  "comemo 0.4.0",
  "dirs 5.0.1",
- "duckdb",
  "flate2",
  "futures",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ calamine = "0.33"
 rust_xlsxwriter = "0.93"
 
 # DuckDB
-duckdb = { version = "1.4", features = ["bundled", "parquet", "json"] }
+duckdb = { version = "1.4", features = ["parquet", "json"] }
 
 # Math rendering
 typst = "0.14.2"

--- a/crates/chatty-core/Cargo.toml
+++ b/crates/chatty-core/Cargo.toml
@@ -82,6 +82,11 @@ tempfile.workspace = true
 [target."cfg(unix)".dependencies]
 nix.workspace = true
 
+[target."cfg(not(windows))".dependencies]
+# Enable bundled DuckDB on Linux/macOS (compiles from source)
+# On Windows, bundled fails with MSVC linker errors, so we use DUCKDB_DOWNLOAD_LIB=1 instead
+duckdb = { workspace = true, features = ["bundled"] }
+
 # Optional: GPUI integration (provides `impl Global` for core types)
 gpui = { workspace = true, optional = true }
 

--- a/crates/chatty-gpui/Cargo.toml
+++ b/crates/chatty-gpui/Cargo.toml
@@ -66,9 +66,6 @@ image.workspace = true
 calamine.workspace = true
 rust_xlsxwriter.workspace = true
 
-# DuckDB
-duckdb.workspace = true
-
 # Math rendering
 typst.workspace = true
 typst-svg.workspace = true


### PR DESCRIPTION
The duckdb `bundled` feature compiles DuckDB from source using cc/MSVC, which fails on Windows CI with linker errors. DUCKDB_DOWNLOAD_LIB=1 only works when `bundled` is NOT enabled (the build script ignores the env var when the bundled feature is active via cfg(feature="bundled")).

Fix by moving `bundled` out of the workspace default and into a [target."cfg(not(windows))".dependencies] section in chatty-core, so Linux/macOS compile from source as before while Windows uses DUCKDB_DOWNLOAD_LIB=1 to download pre-built binaries.

Also removes the unused duckdb dependency from chatty-gpui (no source files in that crate reference duckdb directly).

https://claude.ai/code/session_014yfEc1ra6yxRY2CBkQM4HQ