### PR TITLE
Add DropdownMenu import to search settings page

### DIFF
--- a/crates/chatty-gpui/src/settings/views/search_settings_page.rs
+++ b/crates/chatty-gpui/src/settings/views/search_settings_page.rs
@@ -4,7 +4,7 @@ use crate::settings::views::providers_view::masked_api_key_field;
 use gpui::{App, IntoElement, SharedString, Styled};
 use gpui_component::{
     button::Button,
-    menu::PopupMenuItem,
+    menu::{DropdownMenu, PopupMenuItem},
     setting::{NumberFieldOptions, SettingField, SettingGroup, SettingItem, SettingPage},
 };
 


### PR DESCRIPTION
## Summary
Updated the import statement in the search settings page to include `DropdownMenu` from the `gpui_component::menu` module.

## Changes
- Added `DropdownMenu` to the imports from `gpui_component::menu` alongside the existing `PopupMenuItem` import

## Details
This change prepares the search settings page to use the `DropdownMenu` component, likely for an upcoming feature or refactoring that requires dropdown menu functionality in this view.

https://claude.ai/code/session_01FheEnCVDe7UFjsEVsT9NkJ