### PR TITLE
Unify web search and fetch under single internet toggle with richer trace info

### DIFF
--- a/crates/chatty-core/src/factories/agent_factory.rs
+++ b/crates/chatty-core/src/factories/agent_factory.rs
@@ -697,28 +697,35 @@ impl AgentClient {
             None
         };
 
-        // Create search web tool if enabled and API key is configured
-        let search_web_tool: Option<SearchWebTool> = if let Some(ref search_cfg) = search_settings
-            && search_cfg.enabled
+        // Create search web tool — enabled whenever internet access (fetch) is on.
+        // If a search API key is configured, use that provider; otherwise fall back
+        // to DuckDuckGo lite HTML scraping so search always works without API keys.
+        let search_web_tool: Option<SearchWebTool> = if exec_settings
+            .as_ref()
+            .map(|s| s.fetch_enabled)
+            .unwrap_or(true)
         {
             use crate::settings::models::search_settings::SearchProvider;
-            let api_key = match search_cfg.active_provider {
-                SearchProvider::Tavily => search_cfg.tavily_api_key.clone(),
-                SearchProvider::Brave => search_cfg.brave_api_key.clone(),
-            };
-            if let Some(key) = api_key.filter(|k| !k.is_empty()) {
-                tracing::info!(provider = %search_cfg.active_provider, "Search web tool enabled");
-                Some(SearchWebTool::new(
-                    search_cfg.active_provider.clone(),
-                    key,
-                    search_cfg.max_results,
-                ))
-            } else {
-                tracing::info!("Search web tool disabled: no API key for active provider");
-                None
-            }
+            let max_results = search_settings.as_ref().map(|s| s.max_results).unwrap_or(5);
+            // Try to use the configured search API provider if an API key is set
+            let api_tool = search_settings.as_ref().and_then(|search_cfg| {
+                let api_key = match search_cfg.active_provider {
+                    SearchProvider::Tavily => search_cfg.tavily_api_key.clone(),
+                    SearchProvider::Brave => search_cfg.brave_api_key.clone(),
+                };
+                api_key.filter(|k| !k.is_empty()).map(|key| {
+                    tracing::info!(provider = %search_cfg.active_provider, "Search web tool enabled with API provider");
+                    SearchWebTool::new(search_cfg.active_provider.clone(), key, max_results)
+                })
+            });
+            Some(api_tool.unwrap_or_else(|| {
+                tracing::info!(
+                    "Search web tool enabled with DuckDuckGo fallback (no API key configured)"
+                );
+                SearchWebTool::new_fallback(max_results)
+            }))
         } else {
-            tracing::info!("Search web tool disabled by search settings");
+            tracing::info!("Search web tool disabled (internet access is off)");
             None
         };
 
@@ -880,9 +887,27 @@ impl AgentClient {
         // to call list_tools first.
         let mut tool_sections: Vec<String> = Vec::new();
 
-        if fetch_tool.is_some() {
-            tool_sections
-                .push("- **fetch**: Fetch web URLs and return readable text content".to_string());
+        if fetch_tool.is_some() || search_web_tool.is_some() {
+            let has_search_api = search_web_tool.is_some()
+                && search_settings.as_ref().map_or(false, |s| {
+                    use crate::settings::models::search_settings::SearchProvider;
+                    let key = match s.active_provider {
+                        SearchProvider::Tavily => &s.tavily_api_key,
+                        SearchProvider::Brave => &s.brave_api_key,
+                    };
+                    key.as_ref().map_or(false, |k| !k.is_empty())
+                });
+            let search_note = if has_search_api {
+                "search API"
+            } else {
+                "DuckDuckGo fallback"
+            };
+            tool_sections.push(format!(
+                "- **search_web**: Search the web for up-to-date information ({search_note}). \
+                 Use this first when you need current information.\n\
+                 - **fetch**: Fetch any web URL and return its readable text content. \
+                 Use this to read specific pages, documentation, or articles."
+            ));
         }
         if shell_tools.is_some() {
             tool_sections.push(

--- a/crates/chatty-core/src/models/message_types.rs
+++ b/crates/chatty-core/src/models/message_types.rs
@@ -271,6 +271,8 @@ pub fn friendly_tool_name(name: &str) -> String {
         "create_chart" => "Creating chart".to_string(),
         "search_memory" => "Searching memory".to_string(),
         "remember" => "Remembering".to_string(),
+        "search_web" => "Searching online".to_string(),
+        "fetch" => "Fetching".to_string(),
         other => other.to_string(),
     }
 }

--- a/crates/chatty-core/src/tools/search_web_tool.rs
+++ b/crates/chatty-core/src/tools/search_web_tool.rs
@@ -94,16 +94,20 @@ struct BraveResult {
 
 // ── Tool implementation ─────────────────────────────────────────────────────
 
-/// Web search tool that queries Tavily or Brave Search APIs.
+/// Web search tool that queries Tavily or Brave Search APIs,
+/// with a DuckDuckGo fetch-based fallback when no API key is configured.
 #[derive(Clone)]
 pub struct SearchWebTool {
     client: reqwest::Client,
-    provider: SearchProvider,
-    api_key: String,
+    /// None means fallback mode (use DuckDuckGo lite HTML scraping)
+    provider: Option<SearchProvider>,
+    /// None means fallback mode (no API key configured)
+    api_key: Option<String>,
     default_max_results: usize,
 }
 
 impl SearchWebTool {
+    /// Create a search tool backed by a configured API provider (Tavily or Brave).
     pub fn new(provider: SearchProvider, api_key: String, default_max_results: usize) -> Self {
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(SEARCH_TIMEOUT_SECS))
@@ -112,8 +116,24 @@ impl SearchWebTool {
             .expect("Failed to build HTTP client");
         Self {
             client,
-            provider,
-            api_key,
+            provider: Some(provider),
+            api_key: Some(api_key),
+            default_max_results,
+        }
+    }
+
+    /// Create a search tool in fallback mode: uses DuckDuckGo lite HTML scraping.
+    /// This requires no API key and provides basic web search capability.
+    pub fn new_fallback(default_max_results: usize) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(SEARCH_TIMEOUT_SECS))
+            .user_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+            .build()
+            .expect("Failed to build HTTP client");
+        Self {
+            client,
+            provider: None,
+            api_key: None,
             default_max_results,
         }
     }
@@ -122,6 +142,7 @@ impl SearchWebTool {
         &self,
         query: &str,
         max_results: usize,
+        api_key: &str,
     ) -> Result<Vec<SearchResult>, SearchWebToolError> {
         let request = TavilySearchRequest {
             query: query.to_string(),
@@ -132,7 +153,7 @@ impl SearchWebTool {
         let response = self
             .client
             .post("https://api.tavily.com/search")
-            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Authorization", format!("Bearer {}", api_key))
             .json(&request)
             .send()
             .await
@@ -171,11 +192,12 @@ impl SearchWebTool {
         &self,
         query: &str,
         max_results: usize,
+        api_key: &str,
     ) -> Result<Vec<SearchResult>, SearchWebToolError> {
         let response = self
             .client
             .get("https://api.search.brave.com/res/v1/web/search")
-            .header("X-Subscription-Token", &self.api_key)
+            .header("X-Subscription-Token", api_key)
             .header("Accept", "application/json")
             .query(&[("q", query), ("count", &max_results.to_string() as &str)])
             .send()
@@ -214,6 +236,38 @@ impl SearchWebTool {
 
         Ok(results)
     }
+
+    /// Fallback search using DuckDuckGo lite (no API key required).
+    /// Fetches `https://lite.duckduckgo.com/lite/?q=<query>` and parses the HTML results.
+    async fn search_duckduckgo_fallback(
+        &self,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchResult>, SearchWebToolError> {
+        let response = self
+            .client
+            .get("https://lite.duckduckgo.com/lite/")
+            .query(&[("q", query)])
+            .send()
+            .await
+            .map_err(|e| {
+                SearchWebToolError::SearchError(format!("DuckDuckGo request failed: {}", e))
+            })?;
+
+        if !response.status().is_success() {
+            return Err(SearchWebToolError::SearchError(format!(
+                "DuckDuckGo returned HTTP {}",
+                response.status()
+            )));
+        }
+
+        let html = response.text().await.map_err(|e| {
+            SearchWebToolError::SearchError(format!("Failed to read DuckDuckGo response: {}", e))
+        })?;
+
+        let results = parse_ddg_lite_results(&html, max_results);
+        Ok(results)
+    }
 }
 
 impl Tool for SearchWebTool {
@@ -225,7 +279,7 @@ impl Tool for SearchWebTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: "search_web".to_string(),
-            description: "Search the web using a search engine and return relevant results. \
+            description: "Search the web and return relevant results. \
                          Use this to find up-to-date information, research topics, find documentation, \
                          or answer questions that require current web data."
                 .to_string(),
@@ -259,16 +313,19 @@ impl Tool for SearchWebTool {
             .unwrap_or(self.default_max_results)
             .clamp(1, 20);
 
-        info!(
-            query = %query,
-            max_results = max_results,
-            provider = %self.provider,
-            "Performing web search"
-        );
-
-        let results = match self.provider {
-            SearchProvider::Tavily => self.search_tavily(&query, max_results).await?,
-            SearchProvider::Brave => self.search_brave(&query, max_results).await?,
+        let results = match (&self.provider, &self.api_key) {
+            (Some(SearchProvider::Tavily), Some(key)) => {
+                info!(query = %query, max_results, provider = "tavily", "Performing web search");
+                self.search_tavily(&query, max_results, key).await?
+            }
+            (Some(SearchProvider::Brave), Some(key)) => {
+                info!(query = %query, max_results, provider = "brave", "Performing web search");
+                self.search_brave(&query, max_results, key).await?
+            }
+            _ => {
+                info!(query = %query, max_results, provider = "duckduckgo-fallback", "Performing web search");
+                self.search_duckduckgo_fallback(&query, max_results).await?
+            }
         };
 
         let result_count = results.len();
@@ -282,6 +339,120 @@ impl Tool for SearchWebTool {
             result_count,
         })
     }
+}
+
+/// Parse search results from DuckDuckGo lite HTML.
+///
+/// DDG lite returns a simple table-based HTML page. Each result has:
+/// - A `<a class="result-link">` anchor with href and title text
+/// - A `<td class="result-snippet">` cell with the snippet text
+fn parse_ddg_lite_results(html: &str, max_results: usize) -> Vec<SearchResult> {
+    let mut results = Vec::new();
+
+    // Extract all result links: <a class="result-link" href="...">Title</a>
+    let mut pos = 0;
+    while results.len() < max_results {
+        // Find next result-link anchor
+        let link_marker = "class=\"result-link\"";
+        let Some(link_start) = html[pos..].find(link_marker) else {
+            break;
+        };
+        let link_start = pos + link_start;
+
+        // Find the href attribute within this anchor (search backward for <a)
+        let tag_start = html[..link_start].rfind('<').unwrap_or(link_start);
+
+        // Extract href value
+        let href_marker = "href=\"";
+        let url = if let Some(href_pos) =
+            html[tag_start..link_start + link_marker.len()].find(href_marker)
+        {
+            let href_value_start = tag_start + href_pos + href_marker.len();
+            if let Some(href_end) = html[href_value_start..].find('"') {
+                html[href_value_start..href_value_start + href_end].to_string()
+            } else {
+                pos = link_start + link_marker.len();
+                continue;
+            }
+        } else {
+            pos = link_start + link_marker.len();
+            continue;
+        };
+
+        // Skip non-http URLs (DDG internal links)
+        if !url.starts_with("http") {
+            pos = link_start + link_marker.len();
+            continue;
+        }
+
+        // Extract anchor text (title) — between > and </a>
+        let anchor_close = html[link_start..].find('>');
+        let title = if let Some(close_pos) = anchor_close {
+            let text_start = link_start + close_pos + 1;
+            if let Some(end_anchor) = html[text_start..].find("</a>") {
+                strip_html_tags(&html[text_start..text_start + end_anchor])
+                    .trim()
+                    .to_string()
+            } else {
+                String::new()
+            }
+        } else {
+            String::new()
+        };
+
+        // Find the next result-snippet after this link
+        let snippet_marker = "class=\"result-snippet\"";
+        let snippet = if let Some(snip_start) = html[link_start..].find(snippet_marker) {
+            let snip_start = link_start + snip_start;
+            if let Some(td_close) = html[snip_start..].find('>') {
+                let text_start = snip_start + td_close + 1;
+                if let Some(td_end) = html[text_start..].find("</td>") {
+                    let raw = strip_html_tags(&html[text_start..text_start + td_end]);
+                    truncate_snippet(raw.trim())
+                } else {
+                    String::new()
+                }
+            } else {
+                String::new()
+            }
+        } else {
+            String::new()
+        };
+
+        if !url.is_empty() && !title.is_empty() {
+            results.push(SearchResult {
+                title,
+                url,
+                snippet,
+            });
+        }
+
+        pos = link_start + link_marker.len();
+    }
+
+    results
+}
+
+/// Strip HTML tags from a string, collapsing whitespace
+fn strip_html_tags(html: &str) -> String {
+    let mut result = String::with_capacity(html.len());
+    let mut in_tag = false;
+    for ch in html.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => result.push(ch),
+            _ => {}
+        }
+    }
+    // Decode common HTML entities
+    result
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#x27;", "'")
+        .replace("&nbsp;", " ")
 }
 
 /// Truncate a snippet to a maximum length at a word boundary
@@ -333,5 +504,37 @@ mod tests {
         };
         let result = tool.call(args).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fallback_tool_definition() {
+        let tool = SearchWebTool::new_fallback(5);
+        let def = tool.definition("test".to_string()).await;
+        assert_eq!(def.name, "search_web");
+    }
+
+    #[test]
+    fn test_strip_html_tags() {
+        assert_eq!(strip_html_tags("<b>Hello</b> &amp; world"), "Hello & world");
+        assert_eq!(strip_html_tags("plain text"), "plain text");
+    }
+
+    #[test]
+    fn test_parse_ddg_lite_no_results() {
+        let results = parse_ddg_lite_results("<html><body>No results</body></html>", 5);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parse_ddg_lite_basic() {
+        let html = r#"<html><body>
+            <a class="result-link" href="https://example.com">Example Title</a>
+            <td class="result-snippet">Some snippet text here</td>
+        </body></html>"#;
+        let results = parse_ddg_lite_results(html, 5);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].url, "https://example.com");
+        assert_eq!(results[0].title, "Example Title");
+        assert_eq!(results[0].snippet, "Some snippet text here");
     }
 }

--- a/crates/chatty-gpui/src/chatty/views/trace_components.rs
+++ b/crates/chatty-gpui/src/chatty/views/trace_components.rs
@@ -987,14 +987,14 @@ fn render_full_command_box(
 
 /// Format the inline header text for a tool call.
 ///
-/// Most tools show `$ <command>` (shell-style), but memory tools use their
-/// friendly name as a prefix (e.g. "Remembering: user prefers dark mode").
+/// Most tools show `$ <command>` (shell-style), but internet and memory tools use their
+/// friendly name as a prefix (e.g. "Searching online: rust async patterns").
 fn format_tool_call_header(tool_call: &ToolCallBlock) -> String {
     let detail = extract_command_display(tool_call);
 
     match tool_call.tool_name.as_str() {
-        "remember" | "search_memory" => {
-            // Use the friendly display_name (e.g. "Remembering", "Searching memory")
+        "remember" | "search_memory" | "search_web" | "fetch" => {
+            // Use the friendly display_name as prefix with the detail
             format!("{}: {}", tool_call.display_name, detail)
         }
         _ => format!("$ {}", detail),
@@ -1047,6 +1047,20 @@ fn extract_full_command(tool_call: &ToolCallBlock) -> String {
         if tool_call.tool_name == "search_memory" {
             if let Some(query) = json.get("query").and_then(|v| v.as_str()) {
                 return query.to_string();
+            }
+        }
+
+        // For search_web: extract the search query
+        if tool_call.tool_name == "search_web" {
+            if let Some(query) = json.get("query").and_then(|v| v.as_str()) {
+                return query.to_string();
+            }
+        }
+
+        // For fetch: extract the URL
+        if tool_call.tool_name == "fetch" {
+            if let Some(url) = json.get("url").and_then(|v| v.as_str()) {
+                return url.to_string();
             }
         }
 


### PR DESCRIPTION
- SearchWebTool now supports a DuckDuckGo lite fallback when no API key
  is configured, so internet search always works without requiring Tavily
  or Brave credentials
- agent_factory: search_web tool is now enabled/disabled together with
  the fetch tool (single internet-access toggle), rather than having a
  separate search settings enable flag
- System prompt updated to describe both search_web and fetch as a unified
  internet access capability, noting which search backend is active
- friendly_tool_name: added "Searching online" for search_web and
  "Fetching" for fetch so trace headers show meaningful names
- trace_components: search_web and fetch now use display_name prefix format
  ("Searching online: <query>", "Fetching: <url>") instead of bare $ prefix
- extract_full_command: added explicit handlers for search_web (query field)
  and fetch (url field) so the correct detail is shown in trace headers

https://claude.ai/code/session_01NNbVGiBD1jMGcNFFm7zMMM