### PR TITLE
fix: reliable AppImage squashfs offset detection for pdfium verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,18 +136,23 @@ jobs:
           # Use squashfs-tools to inspect the AppImage's embedded squashfs directly,
           # without executing the AppImage (which may fail in CI due to FUSE restrictions).
           sudo apt-get install -y squashfs-tools > /dev/null 2>&1
-          # An AppImage is an ELF runtime prepended to a squashfs; find the squashfs offset.
-          OFFSET=$(python3 -c "data=open('$APPIMAGE','rb').read();sqsh=data.find(b'sqsh');hsqs=data.find(b'hsqs');print(sqsh if sqsh>=0 else hsqs)")
+          # AppImage Type 2: squashfs is page-aligned (4096 bytes) after the ELF runtime.
+          # Search only at page-aligned offsets to avoid false matches inside the ELF binary.
+          OFFSET=$(python3 -c "data=open('$APPIMAGE','rb').read();print(next((off for off in range(0,len(data)-4,4096) if data[off:off+4] in (b'hsqs',b'sqsh')),-1))")
           if [ "$OFFSET" -lt 0 ]; then
             echo "::error::Could not locate squashfs section inside AppImage — the file may be corrupted or not a valid AppImage"
             exit 1
           fi
-          if unsquashfs -l -o "$OFFSET" "$APPIMAGE" 2>/dev/null | grep -q 'usr/lib/libpdfium\.so'; then
+          echo "Found squashfs at offset $OFFSET"
+          TMPDIR=$(mktemp -d)
+          unsquashfs -d "$TMPDIR" -o "$OFFSET" "$APPIMAGE" usr/lib/libpdfium.so 2>&1
+          if [ -f "$TMPDIR/usr/lib/libpdfium.so" ]; then
             echo "✅ libpdfium.so confirmed inside AppImage"
           else
             echo "::error::libpdfium.so not found in AppImage — PDF tools (pdf_to_image, pdf_extract_text, pdf_info) will not work for users"
             exit 1
           fi
+          rm -rf "$TMPDIR"
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The previous approach searched for 'hsqs'/'sqsh' magic bytes from the start of the AppImage, but these bytes can appear inside the ELF runtime binary, producing a wrong offset and silently failing the unsquashfs call.

Fix: search only at page-aligned offsets (4096-byte boundaries) since AppImage Type 2 always places the squashfs at a page boundary after the ELF. Also switch from 'unsquashfs -l | grep' to extracting the file to a temp dir and checking its existence, which is unambiguous and shows errors on failure.