### PR TITLE
Set up Cloud Agent development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,3 +189,50 @@ examples.
 | WIT reference | [`docs/wit-reference.md`](docs/wit-reference.md) |
 | Release process | [`docs/RELEASE_PROCESS.md`](docs/RELEASE_PROCESS.md) |
 | Coding patterns & behavior | [`CLAUDE.md`](CLAUDE.md) |
+
+## Cursor Cloud specific instructions
+
+Build/test/lint/run commands are unchanged — use the ones documented above
+(the `make` targets / `.github/workflows/ci.yml`). The notes below are only
+the non-obvious environment caveats specific to the Cloud Agent VM. System
+packages, the Rust toolchain, and the `cc`/`c++` alternatives below are baked
+into the VM; the startup/update script only re-runs
+`rustup target add wasm32-wasip2` + `make wasm-modules`.
+
+- **Toolchain must be ≥ 1.85 (edition 2024).** The base VM image historically
+  pinned `rustup default` to an older toolchain (1.83), which cannot compile
+  this workspace (`feature edition2024 is required`). The default is set to
+  `stable`. If a build suddenly fails with an edition-2024 error, run
+  `rustup default stable`.
+
+- **Use GNU `cc`/`c++`, not clang.** `/usr/bin/cc` and `/usr/bin/c++` are
+  pointed at `gcc`/`g++` via `update-alternatives`. The system clang cannot
+  find libstdc++ headers/lib, which breaks the bundled DuckDB C++ build
+  (`fatal error: 'memory' file not found`) and linking the desktop binary
+  (`rust-lld: error: unable to find library -lstdc++`). If you see either
+  error, run `sudo update-alternatives --set cc /usr/bin/gcc` and
+  `sudo update-alternatives --set c++ /usr/bin/g++`.
+
+- **`modules/echo-agent/echo_agent.wasm` is git-ignored** and required by some
+  integration tests, so it must be regenerated after a fresh checkout. The
+  update script runs `make wasm-modules`; run it yourself if `make test` fails
+  with a missing-`.wasm` error.
+
+- **Running the GPUI desktop app (`chatty`) headlessly.** The VM has no GPU,
+  but software Vulkan (Mesa `llvmpipe`/lavapipe) is installed, so the app runs
+  with CPU rendering on the existing X11 display (`DISPLAY=:1`). You MUST export
+  `XDG_RUNTIME_DIR` first, e.g.
+  `export XDG_RUNTIME_DIR=/tmp/xdg-runtime-$(id -u) && mkdir -p "$XDG_RUNTIME_DIR" && chmod 700 "$XDG_RUNTIME_DIR"`,
+  otherwise X11 window creation fails with `BadMatch`. `chatty-tui` needs none
+  of this.
+
+- **No LLM API key is configured.** To actually chat (either frontend), use a
+  local Ollama: start it with `ollama serve` (systemd is not running, so launch
+  it yourself in a background/tmux session), `ollama pull qwen2.5:0.5b`, then
+  `./target/debug/chatty-tui --ollama http://localhost:11434 --model qwen2.5:0.5b --headless -m "..."`.
+  The desktop app auto-detects a running local Ollama and lists its models.
+
+- **Clippy has pre-existing findings under current stable.** `cargo clippy -- -D warnings`
+  currently fails on 3 lints that predate this environment work
+  (`models/conversations_store.rs`, `services/skill_service.rs`,
+  `tools/search_memory_tool.rs`) — newer-toolchain lints, not env breakage.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for Chatty and documents the non-obvious VM caveats discovered during setup. The only code change is an additive `## Cursor Cloud specific instructions` section in `AGENTS.md` — no application code was modified.

## What was set up

- Installed the Linux GPU/build system packages (`scripts/setup-linux.sh`), the `wasm32-wasip2` Rust target, and built the `echo-agent` WASM module needed by tests.
- Set the default Rust toolchain to `stable` (1.98) — the base image pinned 1.83, which cannot build this edition-2024 workspace.
- Repointed `cc`/`c++` `update-alternatives` from clang to `gcc`/`g++`. clang could not find libstdc++, which broke the bundled DuckDB C++ build (`'memory' file not found`) and linking the desktop binary (`unable to find library -lstdc++`).
- Installed Mesa software Vulkan (`llvmpipe`/lavapipe) so the GPUI desktop app renders on CPU (the VM has no GPU), plus a local Ollama + `qwen2.5:0.5b` so both frontends can actually chat (no LLM API key is configured).

## Verification (agreed scope: full dev readiness for both frontends)

| Service | Command | Result |
|---|---|---|
| Build | `cargo build` | ✅ both `chatty` and `chatty-tui` compile |
| Test | `cargo test --all-features -- --test-threads=1` | ✅ all suites pass |
| Lint (fmt) | `cargo fmt --check` | ✅ passes |
| Lint (clippy) | `cargo clippy -- -D warnings` | ⚠️ runs; 3 pre-existing lint findings under current stable (not from this work) |
| Run — desktop GUI | `./target/debug/chatty` (software Vulkan) | ✅ chatted with local Ollama end-to-end |
| Run — terminal | `./target/debug/chatty-tui --ollama ... --headless -m ...` | ✅ real LLM response |

### Hello-world evidence

Desktop app: sent "What is the capital of France?" and the local Ollama model streamed back "The capital of France is Paris."

[chatty_desktop_ollama_chat_demo.mp4](https://cursor.com/agents/bc-55821293-273b-4e01-85ec-c8176a5b3b70/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchatty_desktop_ollama_chat_demo.mp4)

[Chatty desktop chat result](https://cursor.com/agents/bc-55821293-273b-4e01-85ec-c8176a5b3b70/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchatty_desktop_chat_result.webp)

Terminal frontend (`chatty-tui`):

[chatty-tui headless chat log](https://cursor.com/agents/bc-55821293-273b-4e01-85ec-c8176a5b3b70/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchatty_tui_headless_chat.log)

## Update script (startup)

Minimal, idempotent refresh that runs against a fresh checkout:

```
rustup default stable
rustup target add wasm32-wasip2
make wasm-modules
```

`echo_agent.wasm` is git-ignored, so `make wasm-modules` regenerates the test-required artifact each boot. All system packages, the toolchain, and the `cc`/`c++` alternatives are baked into the VM snapshot.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55821293-273b-4e01-85ec-c8176a5b3b70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55821293-273b-4e01-85ec-c8176a5b3b70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

