### PR TITLE
auto: enable Chatty auto-ship workflows and docs

### DIFF
--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -9,6 +9,10 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
 
 Prepares and executes a new Chatty release. The bump type is `$ARGUMENTS` (defaults to `patch` if not specified).
 
+**Human path only.** Do not use this skill for Linear **Chatty auto-ship** / `ship:auto`
+work — that path labels the PR `ship:auto` + `release:patch` and relies on auto-merge +
+`prepare-release`. This skill is for Marcel-driven releases (PR label or `workflow_dispatch`).
+
 ## Determine Release Method
 
 First, figure out the current context:

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -25,15 +25,31 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowed-tools "Read,WebFetch,WebSearch,Bash(cargo *),Bash(jq *),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh issue close:*),Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(gh issue view:*)"'
+          claude_args: '--allowed-tools "Read,WebFetch,WebSearch,Bash(cargo *),Bash(jq *),Bash(curl *),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh issue close:*),Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(gh issue view:*)"'
           prompt: |
             # Dependency Update Check for Chatty Release
 
-            TASK: Check dependencies for updates and propose grouped tech debt cleanup releases.
-            Do NOT create individual issues per crate. Instead, group updates into coherent
-            tech debt release proposals.
+            TASK: Check dependencies for updates and file work into the correct track.
+            Do NOT create individual issues per crate. Group updates into coherent batches.
+
+            ## Two tracks (binding)
+
+            **Auto-ship track** → Linear project **Chatty auto-ship**
+            (https://linear.app/agents-research/project/chatty-auto-ship-5f83bdaf5c5e,
+            project id `1f9c7583-8e02-44bd-a208-0c976f8006f7`, team Agents-research / AGE):
+            - CRITICAL security / CVE bumps (standalone issue per CVE or per crate)
+            - Safe **infrastructure** patch/minor bumps only (tokio, serde, serde_json,
+              reqwest, azure_* patch/minor — NOT major)
+            - Agents will implement these with GitHub labels `ship:auto` + `release:patch`
+
+            **Human track** → GitHub issues labeled `tech-debt` (NOT Linear auto-ship):
+            - AI/LLM updates (rig-core, rmcp) including majors
+            - UI/Rendering updates (gpui, gpui-component, typst, typst-svg, pdfium-render)
+            - Any **major** bump, large migration, or high blast-radius change
+            - Auth/billing-related deps
 
             ## Dependencies to Check
             Only check dependencies core to the application:
@@ -57,77 +73,90 @@ jobs:
             ## Step 2: Categorize Updates
             Sort each outdated dependency into one of these buckets:
 
-            **CRITICAL (standalone issue)**:
+            **CRITICAL / security (auto-ship, standalone)**:
             - Security vulnerabilities — always file immediately as its own issue
             - Title: "Security: Update {crate} {current} → {latest}"
 
-            **AI/LLM updates (group together)**:
-            - rig-core, rmcp — we want to stay current with AI capabilities
-            - These are high-priority and should be grouped together
+            **Infrastructure safe (auto-ship, group)**:
+            - tokio, serde, serde_json, reqwest, azure_* — patch or minor only
+            - Skip if the bump is major → put in human track instead
 
-            **UI/Rendering updates (group together)**:
+            **AI/LLM updates (human track, group)**:
+            - rig-core, rmcp
+
+            **UI/Rendering updates (human track, group)**:
             - gpui, gpui-component, typst, typst-svg, pdfium-render
 
-            **Infrastructure updates (group together)**:
-            - tokio, serde, reqwest, azure_*, and other supporting crates
-
             **SKIP**:
-            - Patch-only bumps (0.0.x) unless they fix bugs we've hit
+            - Patch-only bumps with no security/bugfix signal (except CRITICAL)
             - Crates already at latest version
             - Updates with no meaningful changelog entries
 
-            ## Step 3: Check for Existing Tech Debt Issues
+            ## Step 3: Deduplicate before creating
             CRITICAL — do this BEFORE creating anything:
+
+            Auto-ship / Linear (if LINEAR_API_KEY is set):
+            - Query open issues in project Chatty auto-ship via Linear GraphQL
+              (filter titles containing "Security:" or "Auto-ship: Infrastructure")
+            - Do not duplicate; comment on existing issues when versions advance
+
+            Human / GitHub:
             - Run: gh issue list --state open --search "Tech Debt" --limit 50
-            - Look for open issues with "Tech Debt" in the title
-            - Note what they already cover (read the issue body if needed with gh issue view)
+            - Note what open tech-debt issues already cover
 
-            ## Step 4: Create or Amend Tech Debt Issues
-            For each non-empty bucket from Step 2:
+            ## Step 4: File work
 
-            **If an open tech debt issue already covers this bucket:**
-            - Read the existing issue body with: gh issue view {number}
-            - Check if the updates you found are already listed
-            - If there are NEW updates not yet in the issue, append them with:
-              gh issue comment {number} --body "..."
-              Include: what's new since last check, updated version targets
-            - Do NOT create a duplicate issue
+            ### Auto-ship → Linear (preferred when LINEAR_API_KEY is set)
 
-            **If no matching open tech debt issue exists:**
-            - Create ONE issue per bucket (not per crate!)
-            - Title format: "Tech Debt: {bucket name} updates"
-              Examples:
+            Use Linear GraphQL `https://api.linear.app/graphql` with header
+            `Authorization: <LINEAR_API_KEY>` (raw key, no Bearer prefix if the secret
+            is already an API key).
+
+            Create issue mutation must:
+            - Set `teamId` for Agents-research (`5903cbf0-a4ad-4d7a-ba33-2f13bf95e18c`)
+            - Set `projectId` to Chatty auto-ship (`1f9c7583-8e02-44bd-a208-0c976f8006f7`)
+            - Title examples:
+              - "Security: Update {crate} {current} → {latest}"
+              - "Auto-ship: Infrastructure updates (tokio, serde, …)"
+            - Body: checklist `- [ ] crate: current → latest`, effort, changelogs,
+              note "ship:auto + release:patch when implementing"
+            - Prefer labels `owner:ai` and `ship:auto` if the API allows attaching them
+
+            If LINEAR_API_KEY is unset or Linear calls fail:
+            - Fall back to GitHub issues with title prefix `[auto-ship]` and labels
+              `ship:auto`, `dependencies` so a Cursor automation can mirror them into Linear.
+
+            ### Human track → GitHub only
+
+            Title format: "Tech Debt: {bucket name} updates"
+            Examples:
               - "Tech Debt: AI/LLM dependency updates (rig-core, rmcp)"
               - "Tech Debt: UI/Rendering updates (gpui, typst)"
-              - "Tech Debt: Infrastructure updates (tokio, serde, azure)"
-            - Body must include:
-              - A checklist of each crate to update: `- [ ] crate: current → latest`
-              - For each crate: one-line summary of why (new feature, bug fix, etc.)
-              - Estimated effort: Low / Medium / High
-              - Any breaking changes or migration notes
-              - Link to relevant changelogs
+            Labels: `tech-debt`, `dependencies`
+            Body: checklist, effort, breaking-change notes, changelogs
+            NEVER put these in Chatty auto-ship.
 
             ## Sizing Guidelines
-            - Each tech debt issue should be completable in roughly 1-3 hours of work
+            - Each issue should be completable in roughly 1-3 hours of work
             - If a bucket has too many updates (>6 crates) or includes a complex migration,
               split it into smaller issues with clear scope
-            - If a bucket has only 1 trivial update, skip it — not worth the issue overhead
+            - If a bucket has only 1 trivial non-security update, skip it
             - Aim for 0-3 issues total per run. Creating 0 issues is perfectly fine.
 
             ## Quality Bar
             Before creating each issue, ask: "Is this actionable and worth a developer's time?"
-            - A good tech debt issue: clear scope, grouped logically, achievable in one session
-            - A bad tech debt issue: single patch bump, no real value, just noise
+            - Auto-ship issues must be low blast-radius (security or safe infra)
+            - Human tech-debt issues cover high-risk majors and UI/LLM bumps
 
             ## Project Context
             Chatty is a desktop chat app using GPUI for UI, rig-core for LLM integration,
             rmcp for MCP support, and typst for math rendering. Stay current with AI/LLM
-            libraries for latest capabilities. For UI and infrastructure, only flag meaningful
-            improvements or security fixes.
+            libraries for latest capabilities — but those stay on the human track.
+            Auto-ship is for CVE fixes and boring infra patches only.
 
             ## Output
             End with a summary:
             1. Table of ALL checked dependencies (including skipped ones)
-               | Crate | Current | Latest | Bump | Action | Reason |
-            2. List of issues created or amended (with issue numbers)
-            3. Total: X issues created, Y issues amended, Z crates skipped
+               | Crate | Current | Latest | Bump | Track | Action | Reason |
+            2. List of Linear / GitHub issues created or amended
+            3. Total: X auto-ship filed, Y human tech-debt filed, Z crates skipped

--- a/.github/workflows/ship-auto-guard.yml
+++ b/.github/workflows/ship-auto-guard.yml
@@ -1,0 +1,84 @@
+name: Ship-auto guard
+
+# Enforces the auto-ship contract on PRs labeled `ship:auto`:
+# - patch release only (no release:minor / release:major)
+# - deny-list for research crates, RESERVED.md, auth, and billing
+# Pure Cargo.toml / Cargo.lock dependency bumps outside the deny-list are allowed.
+#
+# Job always runs so it can be a required status check without blocking
+# non-ship:auto PRs (those take the no-op path).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip when not ship:auto
+        id: gate
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+          if echo "$LABELS" | tr ',' '\n' | grep -qx 'ship:auto'; then
+            echo "enforce=true" >> "$GITHUB_OUTPUT"
+            echo "Enforcing ship:auto contract"
+          else
+            echo "enforce=false" >> "$GITHUB_OUTPUT"
+            echo "No ship:auto label — no-op pass"
+          fi
+
+      - name: Checkout repository
+        if: steps.gate.outputs.enforce == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enforce patch-only release label
+        if: steps.gate.outputs.enforce == 'true'
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+          echo "PR labels: ${LABELS}"
+          if echo "$LABELS" | tr ',' '\n' | grep -qx 'release:minor'; then
+            echo "::error::ship:auto PRs must not carry release:minor (patch only)"
+            exit 1
+          fi
+          if echo "$LABELS" | tr ',' '\n' | grep -qx 'release:major'; then
+            echo "::error::ship:auto PRs must not carry release:major (patch only)"
+            exit 1
+          fi
+          if ! echo "$LABELS" | tr ',' '\n' | grep -qx 'release:patch'; then
+            echo "::error::ship:auto PRs must also carry release:patch"
+            exit 1
+          fi
+
+      - name: Enforce path deny-list
+        if: steps.gate.outputs.enforce == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          CHANGED="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          # Patterns that must never ride the auto-ship path.
+          DENY_REGEX='^(RESERVED\.md|\.cursor/rules/ownership\.mdc|crates/chatty-trace/|crates/chatty-playbook/|crates/chatty-flow/|crates/chatty-optimize/|crates/hive-billing-sdk/|crates/chatty-core/src/auth/|crates/chatty-core/src/settings/models/providers_store\.rs|crates/chatty-gpui/src/settings/.*auth|crates/chatty-tui/src/.*auth)'
+
+          VIOLATIONS="$(echo "$CHANGED" | grep -E "$DENY_REGEX" || true)"
+          if [ -n "$VIOLATIONS" ]; then
+            echo "::error::ship:auto PR touches deny-listed paths (research / reserved / auth / billing):"
+            echo "$VIOLATIONS"
+            exit 1
+          fi
+
+          echo "Path deny-list check passed."

--- a/.github/workflows/ship-auto-merge.yml
+++ b/.github/workflows/ship-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Ship-auto merge
+
+# When a PR carries ship:auto + release:patch, enable GitHub auto-merge (squash)
+# once the PR is open. Required status checks (CI, reserved, ship-auto guard)
+# still gate the actual merge.
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    if: >-
+      github.event.pull_request.draft == false &&
+      contains(github.event.pull_request.labels.*.name, 'ship:auto') &&
+      contains(github.event.pull_request.labels.*.name, 'release:patch') &&
+      !contains(github.event.pull_request.labels.*.name, 'release:minor') &&
+      !contains(github.event.pull_request.labels.*.name, 'release:major') &&
+      startsWith(github.event.pull_request.head.ref, 'auto/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr merge "$PR" --repo "${{ github.repository }}" --auto --squash
+          echo "Auto-merge enabled for PR #$PR"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,20 @@
 >
 > Take only `owner:ai` issues unless told otherwise. Never answer or close a
 > `gate:reflection` issue. Ordinary chatty2 work is unaffected by any of this.
+>
+> ### Auto-ship (zero-human patch releases)
+>
+> Low-risk work may merge and **patch-release** without Marcel when — and only when —
+> all of the following hold:
+>
+> 1. The Linear issue lives in project **[Chatty auto-ship](https://linear.app/agents-research/project/chatty-auto-ship-5f83bdaf5c5e)** (not Self-improving chatty2).
+> 2. The GitHub PR is on branch `auto/*`, titled `auto: …`, and carries labels
+>    `ship:auto` + `release:patch` (never minor/major).
+> 3. CI + `ship-auto-guard` are green; then auto-merge → `prepare-release` tags and builds.
+>
+> **Project membership is the allowlist.** Do not auto-merge solely because an issue has
+> `owner:ai` on another project. Never auto-ship reserved symbols, research crates,
+> auth/billing, or core UX. Failures notify Linear, Slack `#chatty-auto-ship`, and GitHub.
 
 Quick-start guide for AI coding agents working in this repository.
 Optimized for limited context windows: read this first, then dive deeper

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -2,18 +2,36 @@
 
 This document explains how to create a release for Chatty.
 
-## Prerequisites
+## Preferred paths (use these)
 
-1. Version in `Cargo.toml` matches the release version you want to create
-2. All changes are committed and pushed to `main`
+### A. PR merge with a release label (human path)
 
-## Release Workflow Options
+1. Open a PR to `main` with exactly one of `release:patch`, `release:minor`, `release:major`.
+2. Merge when CI is green.
+3. `prepare-release.yml` bumps `Cargo.toml`, commits, tags `vX.Y.Z`, creates the GitHub
+   Release, and calls `release.yml` to build artifacts.
 
-The release pipeline supports **two workflows**:
+On a PR branch, `/create-release patch` (or minor/major) only **adds the label** — it does
+not create a tag by hand.
 
-### Option 1: Tag Push (Automatic)
+### B. Auto-ship (zero-human patch releases)
 
-**Best for:** Quick releases without custom release notes
+For low-risk work filed in Linear project **Chatty auto-ship** only:
+
+1. Agent opens PR: branch `auto/*`, title `auto: …`, labels `ship:auto` + `release:patch`.
+2. `ship-auto-guard.yml` enforces patch-only + path deny-list.
+3. When required checks are green, auto-merge squash-merges to `main`.
+4. Same `prepare-release` → `release.yml` pipeline as (A).
+
+Never hand-tag for auto-ship. Failures notify Linear, Slack `#chatty-auto-ship`, and GitHub.
+
+## Deprecated for routine releases: manual tag / UI draft
+
+Hand-updating `Cargo.toml` and pushing `vX.Y.Z` (or drafting a GitHub Release) is easy to
+desync from `Cargo.toml`. Prefer (A) or (B). The workflows below remain for emergency or
+one-off use only.
+
+### Legacy Option 1: Tag Push
 
 ```bash
 # 1. Update version in Cargo.toml
@@ -37,7 +55,7 @@ git push origin v0.1.21
 - Generates release notes from commits
 - Uploads all build artifacts
 
-### Option 2: GitHub UI Release (Manual)
+### Legacy Option 2: GitHub UI Release
 
 **Best for:** Releases with custom release notes or announcements
 


### PR DESCRIPTION
## Summary
- Adds `ship-auto-guard` and `ship-auto-merge` workflows for zero-human patch releases
- Retargets dependency-check toward Linear **Chatty auto-ship** for CVE/safe infra
- Documents the auto-ship path in AGENTS.md and RELEASE_PROCESS.md

Linear: [AGE-35](https://linear.app/agents-research/issue/AGE-35/auto-ship-enable-guard-auto-merge-and-dependency-routing)

## Test plan
- [x] PR labeled `ship:auto` + `release:patch` on branch `auto/*`
- [ ] `guard` check passes
- [ ] CI green → auto-merge
- [ ] `prepare-release` bumps + tags; `release.yml` builds artifacts


Made with [Cursor](https://cursor.com)