### PR TITLE
Bump version to 0.3.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "chatty-core"
-version = "0.3.26"
+version = "0.3.28"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "chatty-flow"
-version = "0.3.26"
+version = "0.3.28"
 dependencies = [
  "serde",
  "serde_json",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "chatty-gpui"
-version = "0.3.26"
+version = "0.3.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "chatty-module-registry"
-version = "0.3.26"
+version = "0.3.28"
 dependencies = [
  "anyhow",
  "chatty-wasm-runtime",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "chatty-optimize"
-version = "0.3.26"
+version = "0.3.28"
 dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "chatty-playbook"
-version = "0.3.26"
+version = "0.3.28"
 dependencies = [
  "serde",
  "serde_json",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "chatty-protocol-gateway"
-version = "0.3.26"
+version = "0.3.28"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "chatty-trace"
-version = "0.3.26"
+version = "0.3.28"
 dependencies = [
  "serde",
  "serde_json",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "chatty-tui"
-version = "0.3.26"
+version = "0.3.28"
 dependencies = [
  "anyhow",
  "chatty-core",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "chatty-wasm-runtime"
-version = "0.3.26"
+version = "0.3.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5004,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "hive-client"
-version = "0.3.26"
+version = "0.3.28"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.27"
+version = "0.3.28"
 edition = "2024"
 # AGE-26: declared MSRV for shipping research crates (also per-crate rust-version).
 rust-version = "1.85"


### PR DESCRIPTION
Version bump for v0.3.28. Lands through a PR because main is protected (GH006).

Do not add `release:patch` — that would bump twice.


Made with [Cursor](https://cursor.com)