### PR TITLE
Closed-system release security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Check rig exact-minor pins (AGE-26)
         run: bash scripts/check-rig-pins.sh
 
+      - name: Check release authz gates (closed-system)
+        run: bash scripts/check-release-authz.sh
+
   # AGE-26: compile-only canary against crates.io latest rig (informational).
   rig-canary:
     runs-on: ubuntu-latest

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -38,6 +38,11 @@ on:
     branches: [main]
 
 permissions:
+  # contents: tags + release notes; pull-requests: cut-release bump PR;
+  # checks/statuses: intentional Cargo-only bump status stamping (GITHUB_TOKEN
+  # pushes do not trigger pull_request workflows, so required checks are stamped
+  # after verifying the diff is only Cargo.toml / Cargo.lock — see
+  # "Land version bump via pull request"). issues: label create for cut-release.
   contents: write
   pull-requests: write
   issues: write
@@ -56,11 +61,14 @@ env:
 jobs:
   prepare:
     runs-on: ubuntu-latest
-    # Run if: manual trigger OR (PR merged to main AND has a release/cut-release
-    # label AND is not a docs-only PR)
+    # Closed-system: workflow_dispatch is repository_owner only; PR-closed path
+    # requires same-repo head (no fork PRs) plus a release/cut-release label.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
+      (github.event_name == 'workflow_dispatch' &&
+       github.actor == github.repository_owner) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
        !startsWith(github.event.pull_request.head.ref, 'docs/') &&
        !contains(github.event.pull_request.labels.*.name, 'documentation') &&
        (contains(github.event.pull_request.labels.*.name, 'release:patch') ||

--- a/.github/workflows/privileged-labels.yml
+++ b/.github/workflows/privileged-labels.yml
@@ -1,0 +1,38 @@
+name: Privileged labels
+
+# Closed-system: only repository_owner and github-actions[bot] may apply
+# ship:auto, release:patch|minor|major, or cut-release. Anyone else gets the
+# label removed and a PR comment.
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  revoke-unauthorized:
+    if: >-
+      (github.event.label.name == 'ship:auto' ||
+       github.event.label.name == 'release:patch' ||
+       github.event.label.name == 'release:minor' ||
+       github.event.label.name == 'release:major' ||
+       github.event.label.name == 'cut-release') &&
+      github.actor != github.repository_owner &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove privileged label and comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          LABEL: ${{ github.event.label.name }}
+          ACTOR: ${{ github.actor }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr edit "$PR" --repo "$REPO" --remove-label "$LABEL"
+          gh pr comment "$PR" --repo "$REPO" --body \
+            "Removed privileged label \`$LABEL\` added by @$ACTOR. Privileged labels (\`ship:auto\`, \`release:patch|minor|major\`, \`cut-release\`) are repository-owner / GitHub Actions only."
+          echo "Revoked unauthorized label $LABEL from PR #$PR (actor=$ACTOR)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,14 @@ name: Release
 #   1. Called by Prepare Release via workflow_call (primary path)
 #   2. Triggered by a published GitHub Release (fallback)
 #   3. Manual workflow_dispatch when the published event did not fire
-#      (AGE-35 recovery path: rebuild artifacts for an existing tag)
+#      (AGE-35 recovery path: rebuild artifacts for an existing tag).
+#      MUST be dispatched against the tag ref itself so checkout uses github.sha:
+#        gh workflow run release.yml --ref vX.Y.Z -f tag_name=vX.Y.Z
 on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: "Git tag to build from (e.g. v1.2.3)"
+        description: "Git tag to build from (e.g. v1.2.3); must match the workflow ref"
         required: true
         type: string
   workflow_call:
@@ -25,10 +27,8 @@ env:
   CARGO_TERM_COLOR: always
   APP_NAME: chatty
 
-# Caching policy: restore-only. Release jobs check out a tag ref that may originate
-# from workflow_dispatch inputs; writing caches from that context would allow
-# CodeQL "cache poisoning via execution of untrusted code". Warm caches come from
-# CI on main; release builds never save.
+# Caching policy: restore-only. Release workflows must not write default-branch
+# caches (CodeQL cache-poisoning). Warm caches come from CI on main.
 
 jobs:
   # Validate that the tag is immutable, on main, and matches Cargo.toml.
@@ -40,28 +40,63 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       tag_name: ${{ steps.version.outputs.tag_name }}
       git_ref: ${{ steps.version.outputs.git_ref }}
+      # Trusted checkout target for build jobs. On workflow_dispatch this is
+      # github.sha (workflow was run from the tag); never an input-derived ref.
+      checkout_ref: ${{ steps.version.outputs.checkout_ref }}
     steps:
       - name: Resolve tag name
         id: resolve_tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag_name || github.event.inputs.tag_name || '' }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
         run: |
           set -euo pipefail
-          # workflow_call / workflow_dispatch pass tag_name; release event has it on the event object
-          TAG="${{ inputs.tag_name || github.event.inputs.tag_name || github.event.release.tag_name }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # Never check out from the dispatch input (CodeQL cache-poisoning).
+            # Operator must run the workflow FROM the tag ref.
+            if [ "$REF_TYPE" != "tag" ]; then
+              echo "::error::workflow_dispatch must target the tag ref (gh workflow run --ref vX.Y.Z -f tag_name=vX.Y.Z). Got ref_type=$REF_TYPE ref_name=$REF_NAME"
+              exit 1
+            fi
+            TAG="$REF_NAME"
+            INPUT="${INPUT_TAG#refs/tags/}"
+            if [ -n "$INPUT" ] && [ "$INPUT" != "$TAG" ]; then
+              echo "::error::tag_name input ($INPUT) must match dispatch tag ref ($TAG)"
+              exit 1
+            fi
+            MODE="workflow_sha"
+          elif [ "$EVENT_NAME" = "release" ]; then
+            TAG="${RELEASE_TAG#refs/tags/}"
+            MODE="git_ref"
+          else
+            # workflow_call from prepare-release
+            TAG="${INPUT_TAG#refs/tags/}"
+            MODE="git_ref"
+          fi
+
           if [ -z "$TAG" ]; then
             echo "::error::No tag name provided"
             exit 1
           fi
-          # Normalize: accept bare vX.Y.Z or refs/tags/vX.Y.Z; always emit both forms.
-          TAG="${TAG#refs/tags/}"
+          if ! [[ "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::Invalid tag format: $TAG"
+            exit 1
+          fi
+
+          echo "checkout_mode=$MODE" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "git_ref=refs/tags/$TAG" >> "$GITHUB_OUTPUT"
-          echo "Resolved tag: $TAG (git_ref=refs/tags/$TAG)"
+          echo "Resolved tag: $TAG (mode=$MODE)"
 
-      - name: Checkout immutable tag
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Never check out a bare name (could resolve to a branch). Always use refs/tags/.
-          ref: ${{ steps.resolve_tag.outputs.git_ref }}
+          # workflow_dispatch: github.sha is the tag the workflow was run against.
+          # workflow_call / release: immutable refs/tags/… only (never a bare name).
+          ref: ${{ steps.resolve_tag.outputs.checkout_mode == 'git_ref' && steps.resolve_tag.outputs.git_ref || github.sha }}
           fetch-depth: 0
 
       - name: Verify tag ref and ancestry on main
@@ -70,6 +105,8 @@ jobs:
           TAG="${{ steps.resolve_tag.outputs.tag }}"
           GIT_REF="refs/tags/${TAG}"
 
+          # Ensure the tag ref exists (fetch tags if checkout was by SHA).
+          git fetch origin --tags --force
           if ! git show-ref --verify --quiet "$GIT_REF"; then
             echo "::error::Immutable tag ref $GIT_REF does not exist"
             exit 1
@@ -77,6 +114,11 @@ jobs:
 
           git fetch origin main
           TAG_COMMIT="$(git rev-list -n 1 "$GIT_REF")"
+          HEAD_COMMIT="$(git rev-parse HEAD)"
+          if [ "$HEAD_COMMIT" != "$TAG_COMMIT" ]; then
+            echo "::error::Checked-out commit ($HEAD_COMMIT) is not tag $TAG ($TAG_COMMIT)"
+            exit 1
+          fi
           if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
             echo "::error::Tag $TAG ($TAG_COMMIT) is not an ancestor of origin/main — refusing to build"
             exit 1
@@ -89,18 +131,17 @@ jobs:
           set -euo pipefail
           TAG_NAME="${{ steps.resolve_tag.outputs.tag }}"
           GIT_REF="${{ steps.resolve_tag.outputs.git_ref }}"
+          MODE="${{ steps.resolve_tag.outputs.checkout_mode }}"
 
-          # Extract version from tag (remove 'v' prefix if present)
           TAG_VERSION="${TAG_NAME#v}"
           echo "Tag name: $TAG_NAME"
           echo "Tag version: $TAG_VERSION"
           echo "Git ref: $GIT_REF"
+          echo "Checkout mode: $MODE"
 
-          # Extract version from Cargo.toml
           CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           echo "Cargo.toml version: $CARGO_VERSION"
 
-          # Validate they match
           if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
             echo "::error::Version mismatch! Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
             echo "::error::Please update Cargo.toml to version $TAG_VERSION before tagging."
@@ -110,6 +151,12 @@ jobs:
           echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
           echo "git_ref=$GIT_REF" >> "$GITHUB_OUTPUT"
+          if [ "$MODE" = "workflow_sha" ]; then
+            # Break CodeQL taint from dispatch input → checkout ref in build jobs.
+            echo "checkout_ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "checkout_ref=$GIT_REF" >> "$GITHUB_OUTPUT"
+          fi
           echo "✅ Version validated: $TAG_VERSION (tag: $TAG_NAME, ref: $GIT_REF)"
 
   build-linux:
@@ -119,7 +166,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-version.outputs.git_ref }}
+          ref: ${{ needs.validate-version.outputs.checkout_ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -237,7 +284,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-version.outputs.git_ref }}
+          ref: ${{ needs.validate-version.outputs.checkout_ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -331,7 +378,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-version.outputs.git_ref }}
+          ref: ${{ needs.validate-version.outputs.checkout_ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,39 +26,70 @@ env:
   APP_NAME: chatty
 
 jobs:
-  # Validate that the tag version matches Cargo.toml
+  # Validate that the tag is immutable, on main, and matches Cargo.toml.
+  # workflow_dispatch is owner-only (forks / outsiders must not arm releases).
   validate-version:
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' || github.actor == github.repository_owner
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag_name: ${{ steps.version.outputs.tag_name }}
+      git_ref: ${{ steps.version.outputs.git_ref }}
     steps:
       - name: Resolve tag name
         id: resolve_tag
         run: |
+          set -euo pipefail
           # workflow_call / workflow_dispatch pass tag_name; release event has it on the event object
           TAG="${{ inputs.tag_name || github.event.inputs.tag_name || github.event.release.tag_name }}"
           if [ -z "$TAG" ]; then
             echo "::error::No tag name provided"
             exit 1
           fi
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "Resolved tag: $TAG"
+          # Normalize: accept bare vX.Y.Z or refs/tags/vX.Y.Z; always emit both forms.
+          TAG="${TAG#refs/tags/}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "git_ref=refs/tags/$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag: $TAG (git_ref=refs/tags/$TAG)"
 
-      - name: Checkout repository
+      - name: Checkout immutable tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.resolve_tag.outputs.tag }}
+          # Never check out a bare name (could resolve to a branch). Always use refs/tags/.
+          ref: ${{ steps.resolve_tag.outputs.git_ref }}
+          fetch-depth: 0
+
+      - name: Verify tag ref and ancestry on main
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.resolve_tag.outputs.tag }}"
+          GIT_REF="refs/tags/${TAG}"
+
+          if ! git show-ref --verify --quiet "$GIT_REF"; then
+            echo "::error::Immutable tag ref $GIT_REF does not exist"
+            exit 1
+          fi
+
+          git fetch origin main
+          TAG_COMMIT="$(git rev-list -n 1 "$GIT_REF")"
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
+            echo "::error::Tag $TAG ($TAG_COMMIT) is not an ancestor of origin/main — refusing to build"
+            exit 1
+          fi
+          echo "Tag $TAG ($TAG_COMMIT) is an ancestor of origin/main"
 
       - name: Extract and validate version
         id: version
         run: |
+          set -euo pipefail
           TAG_NAME="${{ steps.resolve_tag.outputs.tag }}"
+          GIT_REF="${{ steps.resolve_tag.outputs.git_ref }}"
 
           # Extract version from tag (remove 'v' prefix if present)
           TAG_VERSION="${TAG_NAME#v}"
           echo "Tag name: $TAG_NAME"
           echo "Tag version: $TAG_VERSION"
+          echo "Git ref: $GIT_REF"
 
           # Extract version from Cargo.toml
           CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
@@ -71,9 +102,10 @@ jobs:
             exit 1
           fi
 
-          echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
-          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-          echo "✅ Version validated: $TAG_VERSION (tag: $TAG_NAME)"
+          echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "git_ref=$GIT_REF" >> "$GITHUB_OUTPUT"
+          echo "✅ Version validated: $TAG_VERSION (tag: $TAG_NAME, ref: $GIT_REF)"
 
   build-linux:
     needs: validate-version
@@ -82,7 +114,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-version.outputs.tag_name }}
+          ref: ${{ needs.validate-version.outputs.git_ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -200,7 +232,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-version.outputs.tag_name }}
+          ref: ${{ needs.validate-version.outputs.git_ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -294,7 +326,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-version.outputs.tag_name }}
+          ref: ${{ needs.validate-version.outputs.git_ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,6 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       tag_name: ${{ steps.version.outputs.tag_name }}
       git_ref: ${{ steps.version.outputs.git_ref }}
-      # Trusted checkout target for build jobs. On workflow_dispatch this is
-      # github.sha (workflow was run from the tag); never an input-derived ref.
-      checkout_ref: ${{ steps.version.outputs.checkout_ref }}
     steps:
       - name: Resolve tag name
         id: resolve_tag
@@ -166,7 +163,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-version.outputs.checkout_ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.validate-version.outputs.git_ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -284,7 +281,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-version.outputs.checkout_ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.validate-version.outputs.git_ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -378,7 +375,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-version.outputs.checkout_ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.validate-version.outputs.git_ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ env:
   CARGO_TERM_COLOR: always
   APP_NAME: chatty
 
+# Caching policy: restore-only. Release jobs check out a tag ref that may originate
+# from workflow_dispatch inputs; writing caches from that context would allow
+# CodeQL "cache poisoning via execution of untrusted code". Warm caches come from
+# CI on main; release builds never save.
+
 jobs:
   # Validate that the tag is immutable, on main, and matches Cargo.toml.
   # workflow_dispatch is owner-only (forks / outsiders must not arm releases).
@@ -119,8 +124,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry and build artifacts
-        uses: actions/cache@v4
+      - name: Restore cargo registry and build artifacts
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/registry
@@ -130,8 +135,8 @@ jobs:
           restore-keys: |
             cargo-release-${{ runner.os }}-
 
-      - name: Cache pdfium library
-        uses: actions/cache@v4
+      - name: Restore pdfium library
+        uses: actions/cache/restore@v4
         with:
           path: |
             crates/chatty-core/libs
@@ -237,8 +242,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry and build artifacts
-        uses: actions/cache@v4
+      - name: Restore cargo registry and build artifacts
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/registry
@@ -248,8 +253,8 @@ jobs:
           restore-keys: |
             cargo-release-${{ runner.os }}-
 
-      - name: Cache pdfium library
-        uses: actions/cache@v4
+      - name: Restore pdfium library
+        uses: actions/cache/restore@v4
         with:
           path: |
             crates/chatty-core/libs
@@ -331,8 +336,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry and build artifacts
-        uses: actions/cache@v4
+      - name: Restore cargo registry and build artifacts
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/registry
@@ -342,8 +347,8 @@ jobs:
           restore-keys: |
             cargo-release-${{ runner.os }}-
 
-      - name: Cache pdfium library
-        uses: actions/cache@v4
+      - name: Restore pdfium library
+        uses: actions/cache/restore@v4
         with:
           path: |
             crates/chatty-core/libs

--- a/.github/workflows/ship-auto-guard.yml
+++ b/.github/workflows/ship-auto-guard.yml
@@ -1,12 +1,11 @@
 name: Ship-auto guard
 
-# Enforces the auto-ship contract on PRs labeled `ship:auto`:
-# - patch release only (no release:minor / release:major)
-# - deny-list for research crates, RESERVED.md, auth, and billing
-# Pure Cargo.toml / Cargo.lock dependency bumps outside the deny-list are allowed.
+# Enforces release safety on privileged PRs:
+# - Path deny-list for ANY PR labeled release:patch|minor|major
+# - For ship:auto subset: patch-only, require release:patch, prefer auto/* branch
 #
-# Job always runs so it can be a required status check without blocking
-# non-ship:auto PRs (those take the no-op path).
+# Job always runs so it can be a required status check without blocking ordinary
+# PRs (those take the no-op path when no privileged release labels are present).
 
 on:
   pull_request:
@@ -20,18 +19,37 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip when not ship:auto
+      - name: Classify privileged labels
         id: gate
         env:
           LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
+          HAS_RELEASE=false
+          HAS_SHIP_AUTO=false
+          if echo "$LABELS" | tr ',' '\n' | grep -Eqx 'release:(patch|minor|major)'; then
+            HAS_RELEASE=true
+          fi
           if echo "$LABELS" | tr ',' '\n' | grep -qx 'ship:auto'; then
+            HAS_SHIP_AUTO=true
+          fi
+
+          echo "has_release=$HAS_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "has_ship_auto=$HAS_SHIP_AUTO" >> "$GITHUB_OUTPUT"
+
+          if [ "$HAS_RELEASE" = "true" ] || [ "$HAS_SHIP_AUTO" = "true" ]; then
             echo "enforce=true" >> "$GITHUB_OUTPUT"
-            echo "Enforcing ship:auto contract"
+            echo "Privileged release labels present — enforcing guards"
           else
             echo "enforce=false" >> "$GITHUB_OUTPUT"
-            echo "No ship:auto label — no-op pass"
+            echo "No privileged release labels — no-op pass"
+          fi
+
+          # Prefer auto/* for ship:auto (same contract as ship-auto-merge).
+          if [ "$HAS_SHIP_AUTO" = "true" ] && [[ "$HEAD_REF" != auto/* ]]; then
+            echo "::error::ship:auto PRs must use an auto/* branch (got: $HEAD_REF)"
+            exit 1
           fi
 
       - name: Checkout repository
@@ -40,8 +58,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Enforce patch-only release label
-        if: steps.gate.outputs.enforce == 'true'
+      - name: Enforce ship:auto patch-only contract
+        if: steps.gate.outputs.has_ship_auto == 'true'
         env:
           LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
@@ -61,7 +79,7 @@ jobs:
           fi
 
       - name: Enforce path deny-list
-        if: steps.gate.outputs.enforce == 'true'
+        if: steps.gate.outputs.has_release == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -71,12 +89,12 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED"
 
-          # Patterns that must never ride the auto-ship path.
+          # Patterns that must never ride a privileged release path.
           DENY_REGEX='^(RESERVED\.md|\.cursor/rules/ownership\.mdc|crates/chatty-trace/|crates/chatty-playbook/|crates/chatty-flow/|crates/chatty-optimize/|crates/hive-billing-sdk/|crates/chatty-core/src/auth/|crates/chatty-core/src/settings/models/providers_store\.rs|crates/chatty-gpui/src/settings/.*auth|crates/chatty-tui/src/.*auth)'
 
           VIOLATIONS="$(echo "$CHANGED" | grep -E "$DENY_REGEX" || true)"
           if [ -n "$VIOLATIONS" ]; then
-            echo "::error::ship:auto PR touches deny-listed paths (research / reserved / auth / billing):"
+            echo "::error::Release-labeled PR touches deny-listed paths (research / reserved / auth / billing):"
             echo "$VIOLATIONS"
             exit 1
           fi

--- a/.github/workflows/ship-auto-merge.yml
+++ b/.github/workflows/ship-auto-merge.yml
@@ -1,8 +1,11 @@
 name: Ship-auto merge
 
-# When a PR carries ship:auto + release:patch, enable GitHub auto-merge (squash)
-# once the PR is open. Required status checks (CI, reserved, ship-auto guard)
-# still gate the actual merge.
+# When a PR carries ship:auto + release:patch on an auto/* branch, enable GitHub
+# auto-merge (squash) once the PR is open. Required status checks (CI, reserved,
+# ship-auto guard) still gate the actual merge.
+#
+# Closed-system: same-repo head only; only repository_owner (sender) or
+# github-actions[bot] (actor) may arm auto-merge. Fail closed otherwise.
 
 on:
   pull_request:
@@ -23,6 +26,26 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'auto/')
     runs-on: ubuntu-latest
     steps:
+      - name: Require same-repo head and owner/Actions actor
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          REPO: ${{ github.repository }}
+          SENDER: ${{ github.event.sender.login }}
+          ACTOR: ${{ github.actor }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [ "$HEAD_REPO" != "$REPO" ]; then
+            echo "::error::ship:auto auto-merge refused: head repo ($HEAD_REPO) is not $REPO"
+            exit 1
+          fi
+          if [ "$SENDER" = "$OWNER" ] || [ "$ACTOR" = "github-actions[bot]" ]; then
+            echo "Authorized: sender=$SENDER actor=$ACTOR owner=$OWNER"
+          else
+            echo "::error::ship:auto auto-merge refused: sender ($SENDER) / actor ($ACTOR) is not repository_owner ($OWNER) or github-actions[bot]"
+            exit 1
+          fi
+
       - name: Enable auto-merge (squash)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,14 +21,20 @@
 > all of the following hold:
 >
 > 1. The Linear issue lives in project **[Chatty auto-ship](https://linear.app/agents-research/project/chatty-auto-ship-5f83bdaf5c5e)** (not Self-improving chatty2).
+>    Project members = Marcel (closed-system allowlist).
 > 2. The GitHub PR is on branch `auto/*`, titled `auto: …`, and carries labels
->    `ship:auto` + `release:patch` (never minor/major).
-> 3. CI + `ship-auto-guard` are green; then auto-merge → `prepare-release` lands the
->    version bump via a `cut-release` PR (main is protected), tags, and builds.
+>    `ship:auto` + `release:patch` (never minor/major). Privileged labels are
+>    owner / `github-actions[bot]` only; outsiders are stripped.
+> 3. CI + `ship-auto-guard` are green; then auto-merge (same-repo head; owner sender
+>    or Actions actor) → `prepare-release` lands the version bump via a `cut-release`
+>    PR (main is protected), tags, and builds.
 >
 > **Project membership is the allowlist.** Do not auto-merge solely because an issue has
 > `owner:ai` on another project. Never auto-ship reserved symbols, research crates,
-> auth/billing, or core UX. Failures notify Linear, Slack `#chatty-auto-ship`, and GitHub.
+> auth/billing, or core UX. Slack `#chatty-auto-ship` is notify-only. Failures notify
+> Linear, Slack, and GitHub. Emergency rebuild (owner only):
+> `gh workflow run release.yml -f tag_name=vX.Y.Z`.
+> Authz regression: `bash scripts/check-release-authz.sh`.
 
 Quick-start guide for AI coding agents working in this repository.
 Optimized for limited context windows: read this first, then dive deeper

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@
 > **Project membership is the allowlist.** Do not auto-merge solely because an issue has
 > `owner:ai` on another project. Never auto-ship reserved symbols, research crates,
 > auth/billing, or core UX. Slack `#chatty-auto-ship` is notify-only. Failures notify
-> Linear, Slack, and GitHub. Emergency rebuild (owner only):
-> `gh workflow run release.yml -f tag_name=vX.Y.Z`.
+> Linear, Slack, and GitHub. Emergency rebuild (owner only; run against the tag):
+> `gh workflow run release.yml --ref vX.Y.Z -f tag_name=vX.Y.Z`.
 > Authz regression: `bash scripts/check-release-authz.sh`.
 
 Quick-start guide for AI coding agents working in this repository.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -15,14 +15,15 @@ Forks and outside collaborators cannot:
 Linear project **Chatty auto-ship** membership is Marcel (and agents he runs). Slack
 `#chatty-auto-ship` is **notify-only** — not an arming channel.
 
-**Emergency rebuild** (owner only), when a published release event did not fire:
+**Emergency rebuild** (owner only), when a published release event did not fire.
+Dispatch **against the tag ref** (never from `main` with only an input):
 
 ```bash
-gh workflow run release.yml -f tag_name=vX.Y.Z
+gh workflow run release.yml --ref vX.Y.Z -f tag_name=vX.Y.Z
 ```
 
-`release.yml` verifies `refs/tags/vX.Y.Z` exists, checks that commit out, asserts the
-tag is an ancestor of `origin/main`, and matches `Cargo.toml` before building.
+`release.yml` verifies the checked-out commit matches `refs/tags/vX.Y.Z`, asserts that
+commit is an ancestor of `origin/main`, and matches `Cargo.toml` before building.
 
 Authz gate regression check: `bash scripts/check-release-authz.sh` (also run in CI).
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -2,12 +2,38 @@
 
 This document explains how to create a release for Chatty.
 
+## Closed-system security contract
+
+Only **`github.repository_owner`** and **`github-actions[bot]`** may arm releases.
+Forks and outside collaborators cannot:
+
+- Dispatch `release.yml` / `prepare-release.yml` manually
+- Apply privileged labels (`ship:auto`, `release:patch|minor|major`, `cut-release`)
+- Enable ship-auto auto-merge
+- Trigger prepare-release from a fork PR head
+
+Linear project **Chatty auto-ship** membership is Marcel (and agents he runs). Slack
+`#chatty-auto-ship` is **notify-only** — not an arming channel.
+
+**Emergency rebuild** (owner only), when a published release event did not fire:
+
+```bash
+gh workflow run release.yml -f tag_name=vX.Y.Z
+```
+
+`release.yml` verifies `refs/tags/vX.Y.Z` exists, checks that commit out, asserts the
+tag is an ancestor of `origin/main`, and matches `Cargo.toml` before building.
+
+Authz gate regression check: `bash scripts/check-release-authz.sh` (also run in CI).
+
 ## Preferred paths (use these)
 
 ### A. PR merge with a release label (human path)
 
-1. Open a PR to `main` with exactly one of `release:patch`, `release:minor`, `release:major`.
-2. Merge when CI is green.
+1. Open a PR to `main` with exactly one of `release:patch`, `release:minor`, `release:major`
+   (owner-applied; unauthorized labelers are stripped by `privileged-labels.yml`).
+2. Merge when CI is green. `ship-auto-guard` enforces the path deny-list on any
+   release-labeled PR.
 3. `prepare-release.yml` bumps `Cargo.toml` on a `release/vX.Y.Z` PR (`cut-release`,
    not `release:patch`), merges that PR (main is protected — a direct push gets GH006),
    tags `vX.Y.Z`, creates the GitHub Release, and calls `release.yml` to build artifacts.
@@ -19,8 +45,11 @@ not create a tag by hand.
 
 For low-risk work filed in Linear project **Chatty auto-ship** only:
 
-1. Agent opens PR: branch `auto/*`, title `auto: …`, labels `ship:auto` + `release:patch`.
-2. `ship-auto-guard.yml` enforces patch-only + path deny-list.
+1. Agent opens PR: branch `auto/*`, title `auto: …`, labels `ship:auto` + `release:patch`
+   (owner/Actions only).
+2. `ship-auto-guard.yml` enforces patch-only + path deny-list; `ship-auto-merge.yml`
+   enables squash auto-merge only for same-repo heads when the sender is the owner or
+   the actor is `github-actions[bot]`.
 3. When required checks are green, auto-merge squash-merges to `main`.
 4. Same `prepare-release` → bump PR → tag → `release.yml` pipeline as (A).
 

--- a/scripts/check-release-authz.sh
+++ b/scripts/check-release-authz.sh
@@ -42,7 +42,11 @@ need "$WF/release.yml" \
 
 need "$WF/release.yml" \
   'git_ref' \
-  "release.yml exports git_ref for checkout steps"
+  "release.yml exports git_ref for tag uploads / immutable refs"
+
+need "$WF/release.yml" \
+  'workflow_dispatch must target the tag ref|checkout_mode=workflow_sha' \
+  "release.yml does not check out workflow_dispatch inputs as refs"
 
 need "$WF/prepare-release.yml" \
   'github\.actor == github\.repository_owner' \

--- a/scripts/check-release-authz.sh
+++ b/scripts/check-release-authz.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# check-release-authz.sh — assert closed-system release authz gates exist in workflows.
+#
+# Threat model: only github.repository_owner and github-actions[bot] may arm
+# releases; fork / outsider PRs must not. Run locally or from CI:
+#
+#   bash scripts/check-release-authz.sh
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WF="$ROOT/.github/workflows"
+fail=0
+
+need() {
+  local file="$1"
+  local pattern="$2"
+  local desc="$3"
+  if ! grep -Eq "$pattern" "$file"; then
+    echo "FAIL: $desc"
+    echo "  file: $file"
+    echo "  expected pattern: $pattern"
+    fail=1
+  else
+    echo "OK: $desc"
+  fi
+}
+
+echo "Checking release authz gates under .github/workflows/"
+
+need "$WF/release.yml" \
+  'github\.actor == github\.repository_owner' \
+  "release.yml gates workflow_dispatch to repository_owner"
+
+need "$WF/release.yml" \
+  'refs/tags/' \
+  "release.yml checks out immutable refs/tags/ refs"
+
+need "$WF/release.yml" \
+  'merge-base --is-ancestor' \
+  "release.yml asserts tag commit is ancestor of origin/main"
+
+need "$WF/release.yml" \
+  'git_ref' \
+  "release.yml exports git_ref for checkout steps"
+
+need "$WF/prepare-release.yml" \
+  'github\.actor == github\.repository_owner' \
+  "prepare-release.yml gates workflow_dispatch to repository_owner"
+
+need "$WF/prepare-release.yml" \
+  'head\.repo\.full_name == github\.repository' \
+  "prepare-release.yml requires same-repo PR head"
+
+need "$WF/ship-auto-merge.yml" \
+  'head\.repo\.full_name|HEAD_REPO' \
+  "ship-auto-merge.yml requires same-repo head"
+
+need "$WF/ship-auto-merge.yml" \
+  'github-actions\[bot\]' \
+  "ship-auto-merge.yml allows github-actions[bot] actor"
+
+need "$WF/ship-auto-merge.yml" \
+  'repository_owner|OWNER' \
+  "ship-auto-merge.yml requires repository_owner sender"
+
+need "$WF/ship-auto-guard.yml" \
+  'release:\(patch\|minor\|major\)|release:patch' \
+  "ship-auto-guard.yml keys off release labels"
+
+need "$WF/privileged-labels.yml" \
+  'pull-requests:\s*write' \
+  "privileged-labels.yml has pull-requests: write"
+
+need "$WF/privileged-labels.yml" \
+  'github-actions\[bot\]' \
+  "privileged-labels.yml allows github-actions[bot]"
+
+need "$WF/privileged-labels.yml" \
+  'remove-label|Remove privileged label' \
+  "privileged-labels.yml removes unauthorized privileged labels"
+
+if [ "$fail" -ne 0 ]; then
+  echo ""
+  echo "check-release-authz.sh: FAILED"
+  exit 1
+fi
+
+echo ""
+echo "check-release-authz.sh: OK"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens Chatty’s release / auto-ship pipelines so only `github.repository_owner` and `github-actions[bot]` can arm releases. Forks and outside collaborators cannot dispatch builds, apply privileged labels, or enable ship-auto merge.

**Not** a `ship:auto` / `release:patch` PR — **human merge only**.

## Changes

### Workflows
- **`release.yml`**: owner-only `workflow_dispatch`; must be dispatched **against the tag** (`gh workflow run release.yml --ref vX.Y.Z -f tag_name=vX.Y.Z`) so build checkouts use `github.sha` (clears CodeQL cache-poisoning); immutable `refs/tags/` for `workflow_call`/`release`; main-ancestry + Cargo.toml match; restore-only caches; outputs `tag_name` + `git_ref`.
- **`prepare-release.yml`**: owner-only dispatch; PR-closed path requires same-repo head; documents intentional cut-release status stamping permissions.
- **`ship-auto-merge.yml`**: same-repo head + (owner sender **or** Actions actor); fail closed.
- **`ship-auto-guard.yml`**: path deny-list for any `release:patch|minor|major` PR; `ship:auto` still patch-only + `release:patch` + `auto/*`; always runs (no-op otherwise) for required-check use.
- **`privileged-labels.yml`** (new): strips unauthorized `ship:auto` / `release:*` / `cut-release` labels and comments.
- **`ci.yml`**: runs `scripts/check-release-authz.sh`.

### Docs / script
- `docs/RELEASE_PROCESS.md` + `AGENTS.md` Auto-ship: closed-system contract, Slack notify-only, emergency tag-ref dispatch.
- `scripts/check-release-authz.sh`: greps workflows for owner / same-repo gates.

## GitHub settings (Marcel applied)

- Actions workflow permissions: write + can create/approve PRs — done.
- Ruleset `12616240`: `~DEFAULT_BRANCH` + required checks `test` / `check-reserved` / `guard` — done.
- Actions Integration bypass: rejected (422) on user-owned repo — leave empty; cut-release status stamping remains the path.

## Check status (tip `633647b`, updated from main)

| Check | Status |
|-------|--------|
| `test` | **pass** |
| `check-reserved` | **pass** |
| `guard` | **pass** |
| CodeQL / Analyze | pass |
| `claude-review` | fail — empty `ANTHROPIC_API_KEY` (not required) |

**Ready for human merge.** Not behind `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c014fc72-ca9f-494e-be3b-c54c12b59417?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c014fc72-ca9f-494e-be3b-c54c12b59417&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

