### PR TITLE
Add select_candidate debug harness for GEPA implementation

### DIFF
--- a/crates/chatty-optimize/examples/select_candidate_debug.rs
+++ b/crates/chatty-optimize/examples/select_candidate_debug.rs
@@ -1,0 +1,77 @@
+//! Manual debug entry for human-reserved [`select_candidate`](chatty_optimize::gepa::select::select_candidate).
+//!
+//! ```bash
+//! cargo run -p chatty-optimize --example select_candidate_debug
+//! cargo run -p chatty-optimize --example select_candidate_debug -- --trials 1000 --seed 42
+//! ```
+//!
+//! Debugger (lldb):
+//! ```bash
+//! cargo build -p chatty-optimize --example select_candidate_debug
+//! rust-lldb target/debug/examples/select_candidate_debug
+//! (lldb) b chatty_optimize::gepa::select::select_candidate
+//! (lldb) run
+//! ```
+
+use chatty_optimize::gepa::select::{paper_dominance_matrix, select_candidate};
+use std::collections::BTreeMap;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let mut trials = 1usize;
+    let mut seed = 42u64;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--trials" => {
+                i += 1;
+                trials = args.get(i).and_then(|s| s.parse().ok()).unwrap_or(1);
+            }
+            "--seed" => {
+                i += 1;
+                seed = args.get(i).and_then(|s| s.parse().ok()).unwrap_or(42);
+            }
+            "--help" | "-h" => {
+                println!(
+                    "Usage: select_candidate_debug [--trials N] [--seed S]\n\
+                     Exercises select_candidate on the paper dominance matrix."
+                );
+                return;
+            }
+            other => {
+                eprintln!("unknown arg: {other} (try --help)");
+                return;
+            }
+        }
+        i += 1;
+    }
+
+    let matrix = paper_dominance_matrix();
+    print_matrix(&matrix);
+
+    if trials == 1 {
+        match select_candidate(&matrix) {
+            Ok(idx) => println!("selected candidate: {idx}"),
+            Err(e) => eprintln!("error: {e}"),
+        }
+        return;
+    }
+
+    let mut counts: BTreeMap<usize, u32> = BTreeMap::new();
+    for t in 0..trials {
+        let idx = select_candidate(&matrix).unwrap_or_else(|e| panic!("trial {t}: {e}"));
+        *counts.entry(idx).or_insert(0) += 1;
+    }
+    println!("histogram over {trials} trials (seed {seed} is for your RNG if wired later):");
+    for (idx, n) in counts {
+        println!("  candidate {idx}: {n}");
+    }
+}
+
+fn print_matrix(matrix: &[Vec<f64>]) {
+    println!("score_matrix (rows = candidates, cols = instances):");
+    for (i, row) in matrix.iter().enumerate() {
+        println!("  candidate {i}: {row:?}");
+    }
+}

--- a/crates/chatty-optimize/src/gepa/select.rs
+++ b/crates/chatty-optimize/src/gepa/select.rs
@@ -1,6 +1,23 @@
 //! GEPA Pareto candidate selection (AGE-15).
 //!
 //! `select_candidate` is **reserved** — GEPA's actual contribution (~30 lines).
+//!
+//! # Debugging your implementation
+//!
+//! **Prefer the example binary** (always runs, shows `println!` inside `select_candidate`):
+//!
+//! ```bash
+//! cargo run -p chatty-optimize --example select_candidate_debug
+//! ```
+//!
+//! Or the ignored unit test (only exists after the debug harness is merged):
+//!
+//! ```bash
+//! cargo test -p chatty-optimize gepa::select::tests::manual_select_candidate -- --ignored --nocapture
+//! ```
+//!
+//! If you see `running 0 tests`, that test is not in your branch yet — use the example,
+//! or cherry-pick commit `0d45dcb` from `cursor/age-22-walking-skeleton-e949`.
 
 use crate::OptimizeError;
 
@@ -37,16 +54,22 @@ mod tests {
 
     /// Manual debug while implementing (human-reserved).
     ///
-    /// ```bash
-    /// cargo test -p chatty-optimize manual_select_candidate -- --ignored --nocapture
-    /// ```
-    ///
-    /// With lldb: set breakpoint on `select_candidate`, then run the same test under the debugger.
+    /// Full name filter avoids accidentally matching zero tests:
+    /// `cargo test -p chatty-optimize gepa::select::tests::manual_select_candidate -- --ignored --nocapture`
     #[test]
     #[ignore = "manual debug harness — run with --ignored while implementing select_candidate"]
     fn manual_select_candidate() {
         let matrix = paper_dominance_matrix();
         let idx = select_candidate(&matrix).expect("select_candidate");
         println!("selected candidate index: {idx}");
+    }
+
+    /// Prints the paper matrix only — always runnable, no `select_candidate` call.
+    #[test]
+    fn paper_matrix_debug_print() {
+        let matrix = paper_dominance_matrix();
+        for (i, row) in matrix.iter().enumerate() {
+            println!("candidate {i}: {row:?}");
+        }
     }
 }

--- a/crates/chatty-optimize/src/gepa/select.rs
+++ b/crates/chatty-optimize/src/gepa/select.rs
@@ -4,6 +4,18 @@
 
 use crate::OptimizeError;
 
+/// Score matrix from the GEPA paper dominance example (rows = candidates, cols = instances).
+///
+/// Candidate 2 wins only instance 1; candidate 3 wins instances 1 and 2 → 2 is strictly dominated.
+pub fn paper_dominance_matrix() -> Vec<Vec<f64>> {
+    vec![
+        vec![0.0, 0.0], // cand 0
+        vec![1.0, 0.0], // cand 1
+        vec![1.0, 0.0], // cand 2 — wins only instance 1
+        vec![1.0, 1.0], // cand 3 — wins instances 1 and 2
+    ]
+}
+
 /// Instance-wise best → candidates winning ≥1 instance → strict-dominance prune → sample ∝ wins.
 pub fn select_candidate(score_matrix: &[Vec<f64>]) -> Result<usize, OptimizeError> {
     let _ = score_matrix;
@@ -19,13 +31,22 @@ mod tests {
     #[test]
     #[should_panic(expected = "human: select_candidate")]
     fn dominance_example_is_reserved() {
-        // rows = candidates, cols = instances
-        let matrix = vec![
-            vec![0.0, 0.0], // cand 0
-            vec![1.0, 0.0], // cand 1 — best on task 0 only in a fuller example
-            vec![1.0, 0.0], // cand 2 — wins only task 1 in the paper write-up
-            vec![1.0, 1.0], // cand 3 — wins tasks 1 and 2
-        ];
+        let matrix = paper_dominance_matrix();
         let _ = select_candidate(&matrix);
+    }
+
+    /// Manual debug while implementing (human-reserved).
+    ///
+    /// ```bash
+    /// cargo test -p chatty-optimize manual_select_candidate -- --ignored --nocapture
+    /// ```
+    ///
+    /// With lldb: set breakpoint on `select_candidate`, then run the same test under the debugger.
+    #[test]
+    #[ignore = "manual debug harness — run with --ignored while implementing select_candidate"]
+    fn manual_select_candidate() {
+        let matrix = paper_dominance_matrix();
+        let idx = select_candidate(&matrix).expect("select_candidate");
+        println!("selected candidate index: {idx}");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a minimal debug harness for the human-reserved `select_candidate` function (AGE-15), so Marcel can iterate on `auto/test-ship-flow` without waiting for the full AGE-22 walking skeleton PR.

## What's included

- **`examples/select_candidate_debug.rs`** — standalone binary for `cargo run` / lldb breakpoints
- **`paper_dominance_matrix()`** — shared paper-shaped fixture (candidate 2 dominated by 3)
- **`manual_select_candidate`** — ignored unit test for `--ignored --nocapture` debugging
- **`paper_matrix_debug_print`** — always-runnable smoke test (prints matrix only)

## Commands

```bash
cargo run -p chatty-optimize --example select_candidate_debug
cargo test -p chatty-optimize gepa::select::tests::manual_select_candidate -- --ignored --nocapture
cargo test -p chatty-optimize paper_matrix_debug_print -- --nocapture
```

If you see `running 0 tests`, this harness isn't on your branch yet — merge this PR or cherry-pick commits `acad3cf` / `ebd5281`.

## Notes

- Does **not** implement `select_candidate` (reserved per `RESERVED.md`)
- `dominance_example_is_reserved` still expects `todo!` — remove/update when implementation lands
- Separate from #501 (AGE-22 walking skeleton) — debug-only, no trace types or harness wiring
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25e801e7-f2b4-47c3-baf4-e8d071b7e949?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25e801e7-f2b4-47c3-baf4-e8d071b7e949&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

