### PR TITLE
ci: allow cursor bot in claude-code-review for Cloud Agent PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,8 +51,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
 
-          # Cursor cloud-agent PRs use the `cursoragent` account.
-          allowed_bots: cursoragent
+          # Cursor cloud-agent PRs: `cursoragent` (legacy) and `cursor` (Cloud Agent).
+          allowed_bots: cursoragent,cursor
 
           track_progress: true
           use_sticky_comment: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Claude Code Review action validates that `.github/workflows/claude-code-review.yml` on the PR branch is byte-identical to `main`. Workflow fixes must land on `main` first; feature PRs (e.g. #504) cannot carry their own workflow edits or review is skipped.

Cloud Agent PRs are opened by the `cursor` bot account, but `allowed_bots` only listed `cursoragent`. Runs fail with:

```
Workflow initiated by non-human actor: cursor (type: Bot)
```

This adds `cursor` to `allowed_bots` alongside the legacy `cursoragent` account.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04c37-d111-7075-91c6-3d184124dc4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04c37-d111-7075-91c6-3d184124dc4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

