### PR TITLE
AGE-15: human-written select_candidate + GEPA loop scaffolding

### DIFF
--- a/crates/chatty-optimize/examples/evolve_debug.rs
+++ b/crates/chatty-optimize/examples/evolve_debug.rs
@@ -1,0 +1,54 @@
+//! Manual debug entry for Algorithm 1 [`evolve`](chatty_optimize::gepa::evolve::evolve).
+//!
+//! Paper: Agrawal et al., ICLR 2026, arXiv:2507.19457, Algorithm 1 / Figure 4.
+//!
+//! ```bash
+//! cargo run -p chatty-optimize --example evolve_debug
+//! ```
+//!
+//! Debugger (lldb):
+//! ```bash
+//! cargo build -p chatty-optimize --example evolve_debug
+//! rust-lldb target/debug/examples/evolve_debug
+//! (lldb) b chatty_optimize::gepa::evolve::evolve
+//! (lldb) run
+//! ```
+
+use chatty_optimize::gepa::evolve::{GepaConfig, evolve};
+use chatty_optimize::gepa::system::{CompoundSystem, DualKeywordSystem, KeywordSystem};
+
+fn main() {
+    let feedback = vec!["cat".into(), "dog".into(), "bird".into()];
+    let pareto = vec!["cat".into(), "dog".into()];
+    let cfg = GepaConfig::default();
+
+    println!("config: {cfg:?}");
+    println!("D_feedback = {feedback:?}");
+    println!("D_pareto   = {pareto:?}");
+
+    println!("\n--- KeywordSystem (1 module) ---");
+    run(KeywordSystem::new("seed"), &feedback, &pareto, &cfg);
+
+    println!("\n--- DualKeywordSystem (2 modules) ---");
+    run(
+        DualKeywordSystem::new("seed-0", "seed-1"),
+        &feedback,
+        &pareto,
+        &cfg,
+    );
+}
+
+fn run<S: CompoundSystem>(seed: S, feedback: &[String], pareto: &[String], cfg: &GepaConfig) {
+    println!("n_modules = {}", seed.n_modules());
+    let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        evolve(seed, feedback, pareto, cfg)
+    }));
+    match caught {
+        Ok(Ok(result)) => println!(
+            "best_index={} feedback_rollouts={} pareto_rollouts={}",
+            result.best_index, result.state.rollouts.feedback, result.state.rollouts.pareto
+        ),
+        Ok(Err(e)) => eprintln!("error: {e}"),
+        Err(_) => eprintln!("evolve still stubbed (todo! human: Algorithm 1)"),
+    }
+}

--- a/crates/chatty-optimize/examples/select_candidate_debug.rs
+++ b/crates/chatty-optimize/examples/select_candidate_debug.rs
@@ -1,0 +1,77 @@
+//! Manual debug entry for human-reserved [`select_candidate`](chatty_optimize::gepa::select::select_candidate).
+//!
+//! ```bash
+//! cargo run -p chatty-optimize --example select_candidate_debug
+//! cargo run -p chatty-optimize --example select_candidate_debug -- --trials 1000 --seed 42
+//! ```
+//!
+//! Debugger (lldb):
+//! ```bash
+//! cargo build -p chatty-optimize --example select_candidate_debug
+//! rust-lldb target/debug/examples/select_candidate_debug
+//! (lldb) b chatty_optimize::gepa::select::select_candidate
+//! (lldb) run
+//! ```
+
+use chatty_optimize::gepa::select::{paper_dominance_matrix, select_candidate};
+use std::collections::BTreeMap;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let mut trials = 1usize;
+    let mut seed = 42u64;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--trials" => {
+                i += 1;
+                trials = args.get(i).and_then(|s| s.parse().ok()).unwrap_or(1);
+            }
+            "--seed" => {
+                i += 1;
+                seed = args.get(i).and_then(|s| s.parse().ok()).unwrap_or(42);
+            }
+            "--help" | "-h" => {
+                println!(
+                    "Usage: select_candidate_debug [--trials N] [--seed S]\n\
+                     Exercises select_candidate on the paper dominance matrix."
+                );
+                return;
+            }
+            other => {
+                eprintln!("unknown arg: {other} (try --help)");
+                return;
+            }
+        }
+        i += 1;
+    }
+
+    let matrix = paper_dominance_matrix();
+    print_matrix(&matrix);
+
+    if trials == 1 {
+        match select_candidate(&matrix) {
+            Ok(idx) => println!("selected candidate: {idx}"),
+            Err(e) => eprintln!("error: {e}"),
+        }
+        return;
+    }
+
+    let mut counts: BTreeMap<usize, u32> = BTreeMap::new();
+    for t in 0..trials {
+        let idx = select_candidate(&matrix).unwrap_or_else(|e| panic!("trial {t}: {e}"));
+        *counts.entry(idx).or_insert(0) += 1;
+    }
+    println!("histogram over {trials} trials (seed {seed} is for your RNG if wired later):");
+    for (idx, n) in counts {
+        println!("  candidate {idx}: {n}");
+    }
+}
+
+fn print_matrix(matrix: &[Vec<f64>]) {
+    println!("score_matrix (rows = candidates, cols = instances):");
+    for (i, row) in matrix.iter().enumerate() {
+        println!("  candidate {i}: {row:?}");
+    }
+}

--- a/crates/chatty-optimize/examples/select_candidate_debug.rs
+++ b/crates/chatty-optimize/examples/select_candidate_debug.rs
@@ -1,5 +1,7 @@
 //! Manual debug entry for human-reserved [`select_candidate`](chatty_optimize::gepa::select::select_candidate).
 //!
+//! Paper: Agrawal et al., ICLR 2026, arXiv:2507.19457, Algorithm 2 / §3.3.
+//!
 //! ```bash
 //! cargo run -p chatty-optimize --example select_candidate_debug
 //! cargo run -p chatty-optimize --example select_candidate_debug -- --trials 1000 --seed 42

--- a/crates/chatty-optimize/src/ablation.rs
+++ b/crates/chatty-optimize/src/ablation.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 #[serde(default)]
 pub struct AblationConfig {
     /// M3 GEPA: replace Pareto `SelectCandidate` with always-pick-best.
+    /// Agrawal et al. Observation 3 / Table 3 (`SelectBestCandidate` ablation).
     pub select_best_candidate: bool,
     /// M2 AFlow: disable operator library (blank-template / free-form only).
     pub no_operator: bool,

--- a/crates/chatty-optimize/src/gepa/evolve.rs
+++ b/crates/chatty-optimize/src/gepa/evolve.rs
@@ -1,0 +1,270 @@
+//! GEPA Algorithm 1 loop (AGE-15).
+//!
+//! `evolve` is the control flow you fill in. Helpers below are already implemented:
+//! parent selection (Pareto vs ablation), round-robin module, minibatch sample,
+//! scoring, merge flag (default off; `merge` itself stays reserved).
+//!
+//! # Reference
+//!
+//! Agrawal et al., *GEPA: Reflective Prompt Evolution Can Outperform Reinforcement
+//! Learning*, ICLR 2026 Oral, arXiv:2507.19457. Algorithm 1 and Figure 4 (left).
+//! <https://arxiv.org/abs/2507.19457>
+//!
+//! # Debugging
+//!
+//! ```bash
+//! cargo run -p chatty-optimize --example evolve_debug
+//! cargo test -p chatty-optimize gepa::evolve::tests::manual_evolve -- --ignored --nocapture
+//! ```
+//!
+//! Algorithm 1 data structures the body should touch:
+//! - `P` / `state.candidates`, `A` / `state.parents`, `S` / `state.scores`
+//! - minibatch of size [`DEFAULT_MINIBATCH`] from `d_feedback`
+//! - accept on minibatch mean; **then** full `d_pareto` into `S`
+//! - `select_candidate` (or [`SelectBestCandidate`] when `config.select_best`)
+//! - `reflection_meta_prompt()` at the UpdatePrompt call site (reserved text; Appendix B)
+//! - `maybe_merge` only if `config.merge` (default `false`, ≤5 invocations; Appendix F)
+
+use super::merge::merge;
+use super::select::select_candidate;
+use super::system::CompoundSystem;
+use super::{DEFAULT_MINIBATCH, SelectBestCandidate};
+use crate::OptimizeError;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+
+/// Rollout budget and ablation knobs. Merge defaults **off**.
+///
+/// Hyperparameters from Agrawal et al., Algorithm 1 (`B`, `b`) and Appendix F (merge cap).
+#[derive(Debug, Clone)]
+pub struct GepaConfig {
+    /// Total rollouts `B` (feedback + pareto combined, as you choose to count).
+    pub budget: u32,
+    /// Paper `b = 3`.
+    pub minibatch: usize,
+    /// System-aware crossover. Default off.
+    pub merge: bool,
+    /// Cap from the paper (≤5).
+    pub max_merge_invocations: u32,
+    /// Ablation: [`SelectBestCandidate`] instead of Pareto [`select_candidate`].
+    pub select_best: bool,
+}
+
+impl Default for GepaConfig {
+    fn default() -> Self {
+        Self {
+            budget: 12,
+            minibatch: DEFAULT_MINIBATCH,
+            merge: false,
+            max_merge_invocations: 5,
+            select_best: false,
+        }
+    }
+}
+
+/// Train-vs-validation rollout split (paper: report them separately).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RolloutCounts {
+    /// Minibatch / `D_feedback` rollouts.
+    pub feedback: u32,
+    /// Full `D_pareto` rollouts (only on accepted children).
+    pub pareto: u32,
+}
+
+impl RolloutCounts {
+    pub fn total(self) -> u32 {
+        self.feedback + self.pareto
+    }
+}
+
+/// Candidate pool `P`, ancestry `A`, instance-wise scores `S` on `D_pareto`.
+#[derive(Debug, Clone)]
+pub struct GepaState<S> {
+    pub candidates: Vec<S>,
+    pub parents: Vec<Option<usize>>,
+    /// `scores[k][i]` = `µ(P[k], d_pareto[i])`.
+    pub scores: Vec<Vec<f64>>,
+    /// Which module each child rewrote (for merge). Seed row is all-false.
+    pub modules_changed: Vec<Vec<bool>>,
+    pub rollouts: RolloutCounts,
+    pub merge_invocations: u32,
+}
+
+/// Outcome of Algorithm 1: best-on-pareto-mean candidate plus the archive.
+#[derive(Debug, Clone)]
+pub struct GepaResult<S> {
+    pub best_index: usize,
+    pub best: S,
+    pub state: GepaState<S>,
+}
+
+/// Algorithm 1 (`SELECTCANDIDATE` is line 7; this function is the outer loop).
+///
+/// Agrawal et al., ICLR 2026, Figure 4 (left) / Algorithm 1. Fill this in — see
+/// the module docs for the data structures.
+pub fn evolve<S: CompoundSystem>(
+    seed: S,
+    d_feedback: &[String],
+    d_pareto: &[String],
+    config: &GepaConfig,
+) -> Result<GepaResult<S>, OptimizeError> {
+    let _ = (seed, d_feedback, d_pareto, config);
+    todo!("human: Algorithm 1 — pool P, minibatch gate, D_pareto on accept, ancestry (AGE-15)");
+}
+
+/// Pareto [`select_candidate`] (Algorithm 2) or mean-argmax ablation (Observation 3).
+pub fn select_parent(scores: &[Vec<f64>], select_best: bool) -> Result<usize, OptimizeError> {
+    if scores.is_empty() {
+        return Err(OptimizeError::InvalidInput("empty candidate pool".into()));
+    }
+    if select_best {
+        let means: Vec<f64> = scores.iter().map(|row| mean(row)).collect();
+        SelectBestCandidate.select(&means)
+    } else {
+        select_candidate(scores)
+    }
+}
+
+/// Round-robin module index (Algorithm 1 `SELECTMODULE`).
+pub fn select_module(iteration: usize, n_modules: usize) -> Result<usize, OptimizeError> {
+    if n_modules == 0 {
+        return Err(OptimizeError::InvalidInput("system has no modules".into()));
+    }
+    Ok(iteration % n_modules)
+}
+
+/// Uniform minibatch of size `b` (or the whole pool if smaller).
+pub fn sample_minibatch(d_feedback: &[String], b: usize) -> Vec<String> {
+    if d_feedback.is_empty() || b == 0 {
+        return Vec::new();
+    }
+    let n = b.min(d_feedback.len());
+    let mut rng = thread_rng();
+    d_feedback.choose_multiple(&mut rng, n).cloned().collect()
+}
+
+pub fn score_all<S: CompoundSystem>(sys: &S, instances: &[String]) -> Vec<f64> {
+    instances.iter().map(|x| sys.evaluate(x)).collect()
+}
+
+pub fn mean(xs: &[f64]) -> f64 {
+    if xs.is_empty() {
+        0.0
+    } else {
+        xs.iter().sum::<f64>() / xs.len() as f64
+    }
+}
+
+/// No-op when merge is off or the invocation cap is hit. Otherwise calls reserved [`merge`].
+///
+/// Appendix F: at most 5 merge invocations; default off in this crate.
+pub fn maybe_merge(
+    config: &GepaConfig,
+    invocations: &mut u32,
+    score_i: f64,
+    score_j: f64,
+    score_ancestor: f64,
+    changed_i: &[bool],
+    changed_j: &[bool],
+) -> Result<Option<Vec<bool>>, OptimizeError> {
+    if !config.merge || *invocations >= config.max_merge_invocations {
+        return Ok(None);
+    }
+    *invocations += 1;
+    Ok(Some(merge(
+        score_i,
+        score_j,
+        score_ancestor,
+        changed_i,
+        changed_j,
+    )?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gepa::select::paper_dominance_matrix;
+    use crate::gepa::system::{DualKeywordSystem, KeywordSystem};
+
+    #[test]
+    #[should_panic(expected = "human: Algorithm 1")]
+    fn evolve_is_a_stub() {
+        let seed = KeywordSystem::new("seed");
+        let feedback = vec!["a".into()];
+        let pareto = vec!["a".into(), "b".into()];
+        let _ = evolve(seed, &feedback, &pareto, &GepaConfig::default());
+    }
+
+    #[test]
+    fn select_parent_paper_matrix_always_picks_3() {
+        let matrix = paper_dominance_matrix();
+        for _ in 0..16 {
+            assert_eq!(select_parent(&matrix, false).unwrap(), 3);
+        }
+    }
+
+    #[test]
+    fn select_parent_ablation_picks_highest_mean() {
+        let scores = vec![vec![0.0, 0.0], vec![1.0, 1.0], vec![0.5, 0.5]];
+        assert_eq!(select_parent(&scores, true).unwrap(), 1);
+    }
+
+    #[test]
+    fn select_module_round_robins() {
+        assert_eq!(select_module(0, 2).unwrap(), 0);
+        assert_eq!(select_module(1, 2).unwrap(), 1);
+        assert_eq!(select_module(2, 2).unwrap(), 0);
+    }
+
+    #[test]
+    fn same_evolve_signature_accepts_both_systems() {
+        fn assert_evolve<S: CompoundSystem>(_: S) {}
+        assert_evolve(KeywordSystem::new("x"));
+        assert_evolve(DualKeywordSystem::new("x", "y"));
+    }
+
+    #[test]
+    fn score_all_matches_evaluate() {
+        let sys = KeywordSystem::new("cat dog");
+        let inst = vec!["cat".into(), "bird".into()];
+        assert_eq!(score_all(&sys, &inst), vec![1.0, 0.0]);
+        assert_eq!(mean(&[1.0, 0.0]), 0.5);
+    }
+
+    #[test]
+    fn maybe_merge_is_noop_when_disabled() {
+        let cfg = GepaConfig::default();
+        assert!(!cfg.merge);
+        let mut n = 0;
+        let out = maybe_merge(&cfg, &mut n, 0.5, 0.6, 0.4, &[true], &[false]).unwrap();
+        assert!(out.is_none());
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "human: merge")]
+    fn maybe_merge_hits_reserved_merge_when_enabled() {
+        let cfg = GepaConfig {
+            merge: true,
+            ..GepaConfig::default()
+        };
+        let mut n = 0;
+        let _ = maybe_merge(&cfg, &mut n, 0.5, 0.6, 0.4, &[true, false], &[false, true]);
+    }
+
+    /// Manual debug while implementing Algorithm 1.
+    #[test]
+    #[ignore = "manual debug harness — run with --ignored while implementing evolve"]
+    fn manual_evolve() {
+        let seed = KeywordSystem::new("seed");
+        let feedback = vec!["a".into(), "b".into(), "c".into()];
+        let pareto = vec!["a".into(), "b".into()];
+        match evolve(seed, &feedback, &pareto, &GepaConfig::default()) {
+            Ok(result) => println!(
+                "best={} rollouts={}/{}",
+                result.best_index, result.state.rollouts.feedback, result.state.rollouts.pareto
+            ),
+            Err(e) => println!("error: {e}"),
+        }
+    }
+}

--- a/crates/chatty-optimize/src/gepa/merge.rs
+++ b/crates/chatty-optimize/src/gepa/merge.rs
@@ -1,10 +1,19 @@
 //! GEPA system-aware crossover (AGE-15).
 //!
 //! `merge` is **reserved**.
+//!
+//! # Reference
+//!
+//! Agrawal et al., *GEPA: Reflective Prompt Evolution Can Outperform Reinforcement
+//! Learning*, ICLR 2026 Oral, arXiv:2507.19457. Appendix F, Algorithms 3 and 4.
+//! Observation 5 discusses when merge helps vs hurts.
+//! <https://arxiv.org/abs/2507.19457>
 
 use crate::OptimizeError;
 
 /// Merge two non-ancestral candidates via common ancestor + desirability + per-module pick.
+///
+/// Agrawal et al., Appendix F: `S[a] ≤ min(S[i], S[j])`, complementary module bits, ≤5 calls.
 pub fn merge(
     score_i: f64,
     score_j: f64,
@@ -30,5 +39,20 @@ mod tests {
     #[should_panic(expected = "human: merge")]
     fn merge_desirability_is_reserved() {
         let _ = merge(0.5, 0.6, 0.4, &[true, false], &[false, true]);
+    }
+
+    /// Spec: common ancestor with `S[a] ≤ min(S[i], S[j])` is eligible.
+    /// Complementary module bits; implementation reserved.
+    #[test]
+    #[should_panic(expected = "human: merge")]
+    fn merge_desirable_pair_is_reserved() {
+        let _ = merge(0.6, 0.7, 0.4, &[true, false], &[false, true]);
+    }
+
+    /// Spec: ancestor stronger than both children is not desirable.
+    #[test]
+    #[should_panic(expected = "human: merge")]
+    fn merge_strong_ancestor_is_reserved() {
+        let _ = merge(0.5, 0.6, 0.9, &[true, false], &[false, true]);
     }
 }

--- a/crates/chatty-optimize/src/gepa/mod.rs
+++ b/crates/chatty-optimize/src/gepa/mod.rs
@@ -1,15 +1,35 @@
-//! GEPA loop scaffolding (AGE-15). Reserved: select_candidate, merge, REFLECTION_META_PROMPT.
+//! GEPA loop scaffolding (AGE-15).
+//!
+//! You fill [`evolve::evolve`] (Algorithm 1). Already wired: [`select::select_candidate`],
+//! [`SelectBestCandidate`], [`evolve::maybe_merge`] (flag default off).
+//! Still reserved: [`merge::merge`], [`prompts::REFLECTION_META_PROMPT`].
+//!
+//! # Reference
+//!
+//! This module implements (parts of) GEPA as described by:
+//! Lakshya A. Agrawal et al., *GEPA: Reflective Prompt Evolution Can Outperform
+//! Reinforcement Learning*, ICLR 2026 Oral.
+//! <https://arxiv.org/abs/2507.19457>
+//!
+//! Mapping: Algorithm 1 / Figure 4 → [`evolve`]; Algorithm 2 / §3.3 → [`select`];
+//! Appendix F (Algorithms 3–4) → [`merge`]; Appendix B → [`prompts`] (text reserved);
+//! Observation 3 / Table 3 → [`SelectBestCandidate`].
 
+pub mod evolve;
 pub mod merge;
 pub mod prompts;
 pub mod select;
+pub mod system;
 
 use crate::OptimizeError;
 
-/// Minibatch size from the paper (b = 3).
+/// Minibatch size `b = 3` (Agrawal et al., ICLR 2026, Algorithm 1 hyperparameters).
 pub const DEFAULT_MINIBATCH: usize = 3;
 
 /// Ablation: always pick the current best instead of Pareto sampling.
+///
+/// Paper: Observation 3 / Table 3 / Figure 6 (`SelectBestCandidate` vs Pareto).
+/// Agrawal et al., arXiv:2507.19457.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SelectBestCandidate;
 

--- a/crates/chatty-optimize/src/gepa/prompts.rs
+++ b/crates/chatty-optimize/src/gepa/prompts.rs
@@ -1,6 +1,14 @@
 //! GEPA reflection meta-prompt (AGE-15).
 //!
 //! `REFLECTION_META_PROMPT` is **reserved**. Do not quote Appendix B here.
+//!
+//! # Reference
+//!
+//! Agrawal et al., *GEPA: Reflective Prompt Evolution Can Outperform Reinforcement
+//! Learning*, ICLR 2026 Oral, arXiv:2507.19457. The wording lives in **Appendix B**;
+//! Observations 1–2 discuss why that text yields declarative instructions rather than
+//! MIPROv2-style quasi-exemplars. Read the appendix; do not paste it into this file.
+//! <https://arxiv.org/abs/2507.19457>
 
 /// Reflection meta-prompt text — human writes from paper Appendix B reasoning.
 pub fn reflection_meta_prompt() -> &'static str {

--- a/crates/chatty-optimize/src/gepa/select.rs
+++ b/crates/chatty-optimize/src/gepa/select.rs
@@ -2,6 +2,12 @@
 //!
 //! `select_candidate` is **reserved** — GEPA's actual contribution (~30 lines).
 //!
+//! # Reference
+//!
+//! Agrawal et al., *GEPA: Reflective Prompt Evolution Can Outperform Reinforcement
+//! Learning*, ICLR 2026 Oral, arXiv:2507.19457. Algorithm 2 / §3.3 and Figure 4 (right).
+//! <https://arxiv.org/abs/2507.19457>
+//!
 //! # Debugging your implementation
 //!
 //! **Prefer the example binary** (always runs, shows `println!` inside `select_candidate`):
@@ -23,7 +29,7 @@ use crate::OptimizeError;
 use rand::distributions::{Distribution, WeightedIndex};
 use rand::thread_rng;
 
-/// Score matrix from the GEPA paper dominance example (rows = candidates, cols = instances).
+/// Score matrix from Agrawal et al. §3.3 (the dominance worked example).
 ///
 /// Candidate 2 wins only instance 1; candidate 3 wins instances 1 and 2 → 2 is strictly dominated.
 pub fn paper_dominance_matrix() -> Vec<Vec<f64>> {
@@ -37,7 +43,7 @@ pub fn paper_dominance_matrix() -> Vec<Vec<f64>> {
 
 /// Instance-wise best → candidates winning ≥1 instance → strict-dominance prune → sample ∝ wins.
 ///
-/// Paper Algorithm 2 (`SELECTCANDIDATE`): `s*` → `P*` → `C` → `D` → `Ĉ` → `f` → sample.
+/// Agrawal et al., Algorithm 2 (`SELECTCANDIDATE`): `s*` → `P*` → `C` → `D` → `Ĉ` → `f` → sample.
 // HUMAN-WRITTEN: select_candidate
 pub fn select_candidate(score_matrix: &[Vec<f64>]) -> Result<usize, OptimizeError> {
     let (_, weights) = pareto_candidates_and_win_counts(score_matrix)?;

--- a/crates/chatty-optimize/src/gepa/select.rs
+++ b/crates/chatty-optimize/src/gepa/select.rs
@@ -1,6 +1,23 @@
 //! GEPA Pareto candidate selection (AGE-15).
 //!
 //! `select_candidate` is **reserved** — GEPA's actual contribution (~30 lines).
+//!
+//! # Debugging your implementation
+//!
+//! **Prefer the example binary** (always runs, shows `println!` inside `select_candidate`):
+//!
+//! ```bash
+//! cargo run -p chatty-optimize --example select_candidate_debug
+//! ```
+//!
+//! Or the ignored unit test (only exists after the debug harness is merged):
+//!
+//! ```bash
+//! cargo test -p chatty-optimize gepa::select::tests::manual_select_candidate -- --ignored --nocapture
+//! ```
+//!
+//! If you see `running 0 tests`, that test is not in your branch yet — use the example,
+//! or cherry-pick commit `0d45dcb` from `cursor/age-22-walking-skeleton-e949`.
 
 use crate::OptimizeError;
 
@@ -37,16 +54,22 @@ mod tests {
 
     /// Manual debug while implementing (human-reserved).
     ///
-    /// ```bash
-    /// cargo test -p chatty-optimize manual_select_candidate -- --ignored --nocapture
-    /// ```
-    ///
-    /// With lldb: set breakpoint on `select_candidate`, then run the same test under the debugger.
+    /// Full name filter avoids accidentally matching zero tests:
+    /// `cargo test -p chatty-optimize gepa::select::tests::manual_select_candidate -- --ignored --nocapture`
     #[test]
     #[ignore = "manual debug harness — run with --ignored while implementing select_candidate"]
     fn manual_select_candidate() {
         let matrix = paper_dominance_matrix();
         let idx = select_candidate(&matrix).expect("select_candidate");
         println!("selected candidate index: {idx}");
+    }
+
+    /// Prints the paper matrix only — always runnable, no `select_candidate` call.
+    #[test]
+    fn paper_matrix_debug_print() {
+        let matrix = paper_dominance_matrix();
+        for (i, row) in matrix.iter().enumerate() {
+            println!("candidate {i}: {row:?}");
+        }
     }
 }

--- a/crates/chatty-optimize/src/gepa/select.rs
+++ b/crates/chatty-optimize/src/gepa/select.rs
@@ -35,8 +35,15 @@ pub fn paper_dominance_matrix() -> Vec<Vec<f64>> {
 
 /// Instance-wise best → candidates winning ≥1 instance → strict-dominance prune → sample ∝ wins.
 pub fn select_candidate(score_matrix: &[Vec<f64>]) -> Result<usize, OptimizeError> {
+    // score_matrix[candidate][instance]
     let _ = score_matrix;
-    todo!("human: select_candidate — instance-wise Pareto + frequency sampling (AGE-15)")
+    // todo!("human: select_candidate — instance-wise Pareto + frequency sampling (AGE-15)");
+
+    for (i, row) in score_matrix.iter().enumerate() {
+        println!("candate:{i}, {row:?}");
+    }
+
+    Ok(0)
 }
 
 #[cfg(test)]

--- a/crates/chatty-optimize/src/gepa/select.rs
+++ b/crates/chatty-optimize/src/gepa/select.rs
@@ -4,6 +4,18 @@
 
 use crate::OptimizeError;
 
+/// Score matrix from the GEPA paper dominance example (rows = candidates, cols = instances).
+///
+/// Candidate 2 wins only instance 1; candidate 3 wins instances 1 and 2 → 2 is strictly dominated.
+pub fn paper_dominance_matrix() -> Vec<Vec<f64>> {
+    vec![
+        vec![0.0, 0.0], // cand 0
+        vec![1.0, 0.0], // cand 1
+        vec![1.0, 0.0], // cand 2 — wins only instance 1
+        vec![1.0, 1.0], // cand 3 — wins instances 1 and 2
+    ]
+}
+
 /// Instance-wise best → candidates winning ≥1 instance → strict-dominance prune → sample ∝ wins.
 pub fn select_candidate(score_matrix: &[Vec<f64>]) -> Result<usize, OptimizeError> {
     let _ = score_matrix;
@@ -19,13 +31,22 @@ mod tests {
     #[test]
     #[should_panic(expected = "human: select_candidate")]
     fn dominance_example_is_reserved() {
-        // rows = candidates, cols = instances
-        let matrix = vec![
-            vec![0.0, 0.0], // cand 0
-            vec![1.0, 0.0], // cand 1 — best on task 0 only in a fuller example
-            vec![1.0, 0.0], // cand 2 — wins only task 1 in the paper write-up
-            vec![1.0, 1.0], // cand 3 — wins tasks 1 and 2
-        ];
+        let matrix = paper_dominance_matrix();
         let _ = select_candidate(&matrix);
+    }
+
+    /// Manual debug while implementing (human-reserved).
+    ///
+    /// ```bash
+    /// cargo test -p chatty-optimize manual_select_candidate -- --ignored --nocapture
+    /// ```
+    ///
+    /// With lldb: set breakpoint on `select_candidate`, then run the same test under the debugger.
+    #[test]
+    #[ignore = "manual debug harness — run with --ignored while implementing select_candidate"]
+    fn manual_select_candidate() {
+        let matrix = paper_dominance_matrix();
+        let idx = select_candidate(&matrix).expect("select_candidate");
+        println!("selected candidate index: {idx}");
     }
 }

--- a/crates/chatty-optimize/src/gepa/select.rs
+++ b/crates/chatty-optimize/src/gepa/select.rs
@@ -20,6 +20,8 @@
 //! or cherry-pick commit `0d45dcb` from `cursor/age-22-walking-skeleton-e949`.
 
 use crate::OptimizeError;
+use rand::distributions::{Distribution, WeightedIndex};
+use rand::thread_rng;
 
 /// Score matrix from the GEPA paper dominance example (rows = candidates, cols = instances).
 ///
@@ -34,16 +36,145 @@ pub fn paper_dominance_matrix() -> Vec<Vec<f64>> {
 }
 
 /// Instance-wise best → candidates winning ≥1 instance → strict-dominance prune → sample ∝ wins.
+///
+/// Paper Algorithm 2 (`SELECTCANDIDATE`): `s*` → `P*` → `C` → `D` → `Ĉ` → `f` → sample.
+// HUMAN-WRITTEN: select_candidate
 pub fn select_candidate(score_matrix: &[Vec<f64>]) -> Result<usize, OptimizeError> {
-    // score_matrix[candidate][instance]
-    let _ = score_matrix;
-    // todo!("human: select_candidate — instance-wise Pareto + frequency sampling (AGE-15)");
+    let (_, weights) = pareto_candidates_and_win_counts(score_matrix)?;
+    let dist =
+        WeightedIndex::new(&weights).map_err(|e| OptimizeError::InvalidInput(e.to_string()))?;
+    // `weights` is indexed by candidate id, so the sample *is* the candidate.
+    Ok(dist.sample(&mut thread_rng()))
+}
 
-    for (i, row) in score_matrix.iter().enumerate() {
-        println!("candate:{i}, {row:?}");
+/// Returns `(Ĉ, weights)`: survivors, and a length-`n` weight vector (index = candidate id).
+fn pareto_candidates_and_win_counts(
+    score_matrix: &[Vec<f64>],
+) -> Result<(Vec<usize>, Vec<f64>), OptimizeError> {
+    let n = score_matrix.len();
+    let n_inst = score_matrix
+        .first()
+        .map(|row| row.len())
+        .ok_or_else(|| OptimizeError::InvalidInput("empty candidate pool".into()))?;
+    if n_inst == 0 {
+        return Err(OptimizeError::InvalidInput(
+            "candidates have no instance scores".into(),
+        ));
+    }
+    if score_matrix.iter().any(|row| row.len() != n_inst) {
+        return Err(OptimizeError::InvalidInput("ragged score matrix".into()));
     }
 
-    Ok(0)
+    // s*[i] = max_k S[k][i]  — best score seen on each instance
+    let mut s_star = score_matrix[0].clone();
+    for row in &score_matrix[1..] {
+        for (i, &score) in row.iter().enumerate() {
+            if score > s_star[i] {
+                s_star[i] = score;
+            }
+        }
+    }
+
+    // P*[i] = { k | S[k][i] = s*[i] }  — every candidate that *ties* for best on instance i
+    let mut p_star: Vec<Vec<usize>> = vec![Vec::new(); n_inst];
+    for (k, row) in score_matrix.iter().enumerate() {
+        for (i, &score) in row.iter().enumerate() {
+            if score == s_star[i] {
+                p_star[i].push(k);
+            }
+        }
+    }
+
+    // C = unique candidates that win (or tie for) at least one instance
+    // p_star.iter().flatten() walks the inner lists in order and yields candidate indices, not scores:
+    // 1, 2, 3, 3
+    // Each yield is k. in_c[k] = true means “this candidate showed up at least once.” Setting true twice is a no-op. That is the uniqueness: membership, not a count.
+
+    // k=1 → [false, true,  false, false]
+    // k=2 → [false, true,  true,  false]
+    // k=3 → [false, true,  true,  true ]
+    // k=3 → [false, true,  true,  true ]   // already true
+    let mut in_c = vec![false; n];
+    for &k in p_star.iter().flatten() {
+        in_c[k] = true;
+    }
+
+    // D: strictly dominated members of C. Φ_j dominates Φ_i iff
+    // S[j][t] ≥ S[i][t] for every instance t, and > for at least one t.
+    // Checked only among C, not the full pool.
+    let mut dominated = vec![false; n];
+    for i in 0..n {
+        if !in_c[i] {
+            continue;
+        }
+        for j in 0..n {
+            if i != j && in_c[j] && strictly_dominates(&score_matrix[j], &score_matrix[i]) {
+                dominated[i] = true;
+                // there is no need to check the remainder as it is already dominated by one
+                break;
+            }
+        }
+    }
+
+    // Ĉ = C \ D
+    let c_hat: Vec<usize> = (0..n).filter(|&k| in_c[k] && !dominated[k]).collect();
+    if c_hat.is_empty() {
+        return Err(OptimizeError::InvalidInput(
+            "Pareto front is empty after dominance pruning".into(),
+        ));
+    }
+
+    // f[Φ] = |{ i | Φ ∈ P*[i] }|  — win *count*, not sum of scores
+    // Paper matrix, step by step
+    //         inst 0   inst 1
+    // 0        0        0
+    // 1        1        0
+    // 2        1        0
+    // 3        1        1
+    // s*     = 1        1
+    // p_star = [1,2,3]  [3]
+    // Start: f = [0, 0, 0, 0]
+
+    // Instance 0, winners = [1, 2, 3]:
+
+    // f[1] += 1  →  [0, 1, 0, 0]
+    // f[2] += 1  →  [0, 1, 1, 0]
+    // f[3] += 1  →  [0, 1, 1, 1]
+    //
+    // It just simply adds 1 for the instance wins
+
+    let mut f = vec![0.0; n];
+    for winners in &p_star {
+        // note that p_star are already all winners
+        for &k in winners {
+            f[k] += 1.0;
+        }
+    }
+
+    // `f` is already the win-count, indexed by candidate id — including dominated
+    // winners, whose `f` is > 0. Zero everyone not in Ĉ so WeightedIndex cannot
+    // pick them. Never-winners are already 0.
+    for (k, weight) in f.iter_mut().enumerate() {
+        if !in_c[k] || dominated[k] {
+            *weight = 0.0;
+        }
+    }
+    Ok((c_hat, f))
+}
+
+fn strictly_dominates(a: &[f64], b: &[f64]) -> bool {
+    let mut strictly_better = false;
+    for (&ai, &bi) in a.iter().zip(b) {
+        // no item can be smaller
+        if ai < bi {
+            return false;
+        }
+        // it should score higher for at least one item
+        if ai > bi {
+            strictly_better = true;
+        }
+    }
+    strictly_better
 }
 
 #[cfg(test)]
@@ -51,12 +182,38 @@ mod tests {
     use super::*;
 
     /// Paper-shaped dominance example: candidate 2 wins only task 1; candidate 3 wins
-    /// tasks 1 and 2 → candidate 2 is pruned. Implementation reserved.
+    /// tasks 1 and 2 → candidate 2 is pruned.
     #[test]
-    #[should_panic(expected = "human: select_candidate")]
-    fn dominance_example_is_reserved() {
+    fn dominance_example_prunes_candidate_2() {
         let matrix = paper_dominance_matrix();
-        let _ = select_candidate(&matrix);
+        let (c_hat, weights) = pareto_candidates_and_win_counts(&matrix).unwrap();
+        assert_eq!(c_hat, vec![3], "only candidate 3 survives the front");
+        assert_eq!(
+            weights,
+            vec![0.0, 0.0, 0.0, 2.0],
+            "dominated winners are zeroed; candidate 3 wins both instances"
+        );
+        for _ in 0..32 {
+            assert_eq!(select_candidate(&matrix).unwrap(), 3);
+        }
+    }
+
+    /// Complementary winners: neither dominates, sample weights equal the win counts.
+    #[test]
+    fn selection_weights_are_win_counts() {
+        let matrix = vec![
+            vec![1.0, 1.0, 0.0], // cand 0 wins instances 0 and 1
+            vec![0.0, 0.0, 1.0], // cand 1 wins instance 2
+        ];
+        let (c_hat, weights) = pareto_candidates_and_win_counts(&matrix).unwrap();
+        assert_eq!(c_hat, vec![0, 1]);
+        assert_eq!(weights, vec![2.0, 1.0]);
+    }
+
+    #[test]
+    fn empty_matrix_is_invalid() {
+        let err = select_candidate(&[]).unwrap_err();
+        assert!(matches!(err, OptimizeError::InvalidInput(_)));
     }
 
     /// Manual debug while implementing (human-reserved).

--- a/crates/chatty-optimize/src/gepa/system.rs
+++ b/crates/chatty-optimize/src/gepa/system.rs
@@ -1,0 +1,117 @@
+//! `CompoundSystem` seam (AGE-15): GEPA is a layer over any multi-module prompt system.
+//!
+//! Two toy impls exist so the same `evolve` binary can run against more than one
+//! system without an LLM. `µ_f` / [`FeedbackFn`](chatty_trace) is still reserved (AGE-5);
+//! `evaluate` is scalar `µ` only.
+//!
+//! # Reference
+//!
+//! Agrawal et al., *GEPA: Reflective Prompt Evolution Can Outperform Reinforcement
+//! Learning*, ICLR 2026 Oral, arXiv:2507.19457. §3: GEPA optimizes a *compound* system
+//! by rewriting one module at a time (`SELECTMODULE`). `µ` vs `µ_f` is the same section.
+//! <https://arxiv.org/abs/2507.19457>
+
+/// A compound AI system whose textual modules GEPA can rewrite.
+pub trait CompoundSystem: Clone {
+    fn n_modules(&self) -> usize;
+    fn prompt(&self, module: usize) -> &str;
+    fn set_prompt(&mut self, module: usize, prompt: String);
+    /// Scalar eval metric `µ` on one instance. Not `µ_f`.
+    fn evaluate(&self, instance: &str) -> f64;
+}
+
+/// Single-module system (chatty2 `ModelConfig.preamble` shape).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeywordSystem {
+    pub preamble: String,
+}
+
+impl KeywordSystem {
+    pub fn new(preamble: impl Into<String>) -> Self {
+        Self {
+            preamble: preamble.into(),
+        }
+    }
+}
+
+impl CompoundSystem for KeywordSystem {
+    fn n_modules(&self) -> usize {
+        1
+    }
+
+    fn prompt(&self, module: usize) -> &str {
+        assert_eq!(module, 0, "KeywordSystem has one module");
+        &self.preamble
+    }
+
+    fn set_prompt(&mut self, module: usize, prompt: String) {
+        assert_eq!(module, 0, "KeywordSystem has one module");
+        self.preamble = prompt;
+    }
+
+    fn evaluate(&self, instance: &str) -> f64 {
+        if self.preamble.contains(instance) {
+            1.0
+        } else {
+            0.0
+        }
+    }
+}
+
+/// Two-module system (placeholder for a multi-hop / `IrRepr` later).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DualKeywordSystem {
+    pub modules: [String; 2],
+}
+
+impl DualKeywordSystem {
+    pub fn new(m0: impl Into<String>, m1: impl Into<String>) -> Self {
+        Self {
+            modules: [m0.into(), m1.into()],
+        }
+    }
+}
+
+impl CompoundSystem for DualKeywordSystem {
+    fn n_modules(&self) -> usize {
+        2
+    }
+
+    fn prompt(&self, module: usize) -> &str {
+        &self.modules[module]
+    }
+
+    fn set_prompt(&mut self, module: usize, prompt: String) {
+        self.modules[module] = prompt;
+    }
+
+    fn evaluate(&self, instance: &str) -> f64 {
+        let joined = format!("{} {}", self.modules[0], self.modules[1]);
+        if joined.contains(instance) { 1.0 } else { 0.0 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keyword_system_is_single_module() {
+        let mut s = KeywordSystem::new("hello world");
+        assert_eq!(s.n_modules(), 1);
+        assert_eq!(s.evaluate("hello"), 1.0);
+        assert_eq!(s.evaluate("xyz"), 0.0);
+        s.set_prompt(0, "xyz".into());
+        assert_eq!(s.evaluate("xyz"), 1.0);
+    }
+
+    #[test]
+    fn dual_system_is_two_modules() {
+        let mut s = DualKeywordSystem::new("hop-a", "hop-b");
+        assert_eq!(s.n_modules(), 2);
+        assert_eq!(s.evaluate("hop-a"), 1.0);
+        s.set_prompt(1, "secret".into());
+        assert_eq!(s.evaluate("secret"), 1.0);
+        assert_eq!(s.prompt(0), "hop-a");
+    }
+}

--- a/crates/chatty-optimize/src/lib.rs
+++ b/crates/chatty-optimize/src/lib.rs
@@ -8,6 +8,9 @@
 //! paired statistics, ablation flags, QA loaders for in-process GEPA/ACE, calibration
 //! stubs, and the reserved ReAct `Strategy`.
 //!
+//! GEPA code in [`gepa`] follows Agrawal et al., *GEPA: Reflective Prompt Evolution
+//! Can Outperform Reinforcement Learning*, ICLR 2026 Oral, arXiv:2507.19457.
+//!
 //! # Reserved
 //!
 //! `SelectionStrategy`, `soft_mixed_select`, `select_candidate`, `merge`,


### PR DESCRIPTION
Relocates GEPA work that was accidentally committed on `auto/test-ship-flow` (a retired auto-ship dry-run branch) onto a dedicated AGE-15 branch from current `main`.

## What's in this PR

- **`select_candidate`** — human-written Pareto sampler (`HUMAN-WRITTEN` marker). Paper dominance example now has a real test instead of `should_panic`.
- Debug harness: `examples/select_candidate_debug.rs` (same idea as draft #502).
- Scaffolding for the rest of AGE-15: `CompoundSystem` (`system.rs`), Algorithm 1 stub (`evolve.rs`), extra reserved `merge` tests.

## Still reserved (left as `todo!("human: …")`)

- `merge()` — Appendix F
- `REFLECTION_META_PROMPT` — Appendix B

`evolve()` is a stub for Algorithm 1; it is not in `RESERVED.md`.

## Out of scope

Does not implement reserved `merge` or the reflection meta-prompt. `auto/test-ship-flow` is left untouched.

Related: AGE-15. Draft #502 is the debug-harness-only PR; this one supersedes it once ready.

Made with [Cursor](https://cursor.com)