### PR TITLE
docs: AGE-117/AGE-116 link checker and nav drift CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,6 +59,15 @@ jobs:
           mdbook build docs-site
           install -m 644 docs/generated/llms.txt docs-site/book/llms.txt
 
+      - name: Install lychee
+        run: cargo install lychee --locked
+
+      - name: Check documentation links
+        run: bash scripts/check-docs-links.sh
+
+      - name: Check docs nav drift (INDEX + SUMMARY)
+        run: bash scripts/check-docs-nav-drift.sh
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,17 @@
+# Link checker config for docs CI (AGE-117).
+# Run via: bash scripts/check-docs-links.sh
+
+exclude_path = [
+  "docs-site/book/**",
+  "target/**",
+  "docs/generated/**",
+]
+
+# Sibling repo (harbor-chatty) is not in this workspace; links are intentional.
+exclude = [
+  '^file:///harbor-chatty',
+  '.*/harbor-chatty$',
+  'https://linear.app/',
+]
+
+offline = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,8 @@ make wasm-modules     # build the echo-agent WASM module (needed by tests)
 make docs-gen         # regenerate docs/generated reference pages
 make docs             # sync + build mdBook site (docs-site/book/)
 make docs-serve       # local preview at http://localhost:3000
+make docs-check-links # lychee link check (AGE-117)
+make docs-check-nav   # INDEX.md + SUMMARY.md drift check (AGE-116)
 make ci               # everything CI runs, locally, in order
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@
 
 .PHONY: help setup build build-release test test-fast test-tui test-gpui \
         test-gateway lint fmt fmt-check typecheck wasm-modules run-gpui \
-        run-tui ci clean docs-gen docs-sync docs docs-serve
+        run-tui ci clean docs-gen docs-sync docs docs-serve docs-check-links \
+        docs-check-nav
 
 help:
 	@echo "Common targets:"
@@ -36,6 +37,8 @@ help:
 	@echo "  make docs-sync     Copy repo markdown into docs-site/src"
 	@echo "  make docs          docs-gen + docs-sync + mdbook build"
 	@echo "  make docs-serve    Local mdBook preview (port 3000)"
+	@echo "  make docs-check-links  Verify markdown links (lychee; AGE-117)"
+	@echo "  make docs-check-nav    Verify INDEX.md + SUMMARY.md completeness (AGE-116)"
 	@echo "  make ci            Everything CI runs, in order"
 
 setup:
@@ -122,3 +125,9 @@ docs: docs-gen docs-sync
 
 docs-serve: docs-gen docs-sync
 	mdbook serve docs-site --open
+
+docs-check-links:
+	bash scripts/check-docs-links.sh
+
+docs-check-nav:
+	bash scripts/check-docs-nav-drift.sh

--- a/docs-site/src/index.md
+++ b/docs-site/src/index.md
@@ -4,9 +4,9 @@ Welcome to the **developer documentation** for [Chatty](https://github.com/boers
 a Rust desktop and terminal AI agent framework.
 
 <div class="hero-links">
-  <a href="dev/architecture/system-overview.html">System overview</a>
-  <a href="dev/architecture/component-map.html" class="secondary">Component map</a>
-  <a href="dev/agents.html" class="secondary">Agent guide</a>
+  <a href="dev/architecture/system-overview.md">System overview</a>
+  <a href="dev/architecture/component-map.md" class="secondary">Component map</a>
+  <a href="dev/agents.md" class="secondary">Agent guide</a>
   <a href="https://github.com/boersmamarcel/chatty" class="secondary">Marketing site</a>
 </div>
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -48,6 +48,11 @@ for coding patterns and behavioural rules read
 | [`research/app-research-bridge.md`](research/app-research-bridge.md) | **App ↔ research map** | Memory, context window, loop, traces → M0–M4 |
 | [`research/paper-to-product-pipeline.md`](research/paper-to-product-pipeline.md) | Research pipeline | SOTA → experiment → product flow |
 | [`research/modules/index.md`](research/modules/index.md) | Per-paper module work | M0–M4 overview and status |
+| [`research/modules/m0-trace.md`](research/modules/m0-trace.md) | chatty-trace / M0 work | Trace contract module notes |
+| [`research/modules/m1-react.md`](research/modules/m1-react.md) | ReAct substrate work | M1 strategy variants |
+| [`research/modules/m2-aflow.md`](research/modules/m2-aflow.md) | chatty-flow / M2 work | AFlow workflow search |
+| [`research/modules/m3-gepa.md`](research/modules/m3-gepa.md) | chatty-optimize / M3 work | GEPA prompt evolution |
+| [`research/modules/m4-ace.md`](research/modules/m4-ace.md) | chatty-playbook / M4 work | ACE playbook deltas |
 | [`research/promotion-log.md`](research/promotion-log.md) | After experiments | Marcel-only promotion verdicts |
 | [`research/settings-integration-map.md`](research/settings-integration-map.md) | Product integration | Settings ↔ research mechanisms |
 | [`research/experiment-protocol.md`](research/experiment-protocol.md) | Running evals | Stage A/B checklist, cost accounting |
@@ -57,6 +62,22 @@ for coding patterns and behavioural rules read
 | [`research/crate-promises-chatty-flow.md`](research/crate-promises-chatty-flow.md) | chatty-flow work | Flow crate scope |
 | [`research/cost-model.md`](research/cost-model.md) | Optimizer economics | Cost model |
 | [`research/appworld-decision.md`](research/appworld-decision.md) | Eval sandbox choice | AppWorld decision |
+
+## Crate READMEs
+
+| File | When to read | What it covers |
+|---|---|---|
+| [`../crates/chatty-core/README.md`](../crates/chatty-core/README.md) | Core crate work | UI-agnostic models, tools, services |
+| [`../crates/chatty-gpui/README.md`](../crates/chatty-gpui/README.md) | Desktop UI work | GPUI binary |
+| [`../crates/chatty-tui/README.md`](../crates/chatty-tui/README.md) | Terminal UI work | Ratatui binary, headless mode |
+| [`../crates/chatty-trace/README.md`](../crates/chatty-trace/README.md) | chatty-trace work | Trace capture crate |
+| [`../crates/chatty-playbook/README.md`](../crates/chatty-playbook/README.md) | chatty-playbook work | ACE playbook crate |
+| [`../crates/chatty-flow/README.md`](../crates/chatty-flow/README.md) | chatty-flow work | Workflow IR crate |
+| [`../crates/chatty-optimize/README.md`](../crates/chatty-optimize/README.md) | Optimizer tooling | Offline GEPA/AFlow (not in app binary) |
+| [`../crates/chatty-wasm-runtime/README.md`](../crates/chatty-wasm-runtime/README.md) | WASM runtime | Wasmtime agent modules |
+| [`../crates/chatty-module-registry/README.md`](../crates/chatty-module-registry/README.md) | Module registry | Discovery and lifecycle |
+| [`../crates/chatty-protocol-gateway/README.md`](../crates/chatty-protocol-gateway/README.md) | HTTP gateway | OpenAI / MCP / A2A protocols |
+| [`../crates/chatty-module-sdk/README.md`](../crates/chatty-module-sdk/README.md) | WASM module SDK | Authoring agent modules |
 
 ## Generated reference (`docs/generated/`)
 

--- a/docs/agent-memory.md
+++ b/docs/agent-memory.md
@@ -129,9 +129,9 @@ This can be changed in the Settings → Execution panel. When disabled, the memo
 
 ## Research connection (ACE / M4)
 
-The memory + `[SKILL]` split is the production substrate for [ACE playbooks](../research/modules/m4-ace.md).
+The memory + `[SKILL]` split is the production substrate for [ACE playbooks](research/modules/m4-ace.md).
 `chatty-playbook` will add Reflector/Curator delta ops and deterministic merge on top of this
-store — see the [app ↔ research bridge](../research/app-research-bridge.md#memory-skills--playbook-m4).
+store — see the [app ↔ research bridge](research/app-research-bridge.md#memory-skills--playbook-m4).
 
 ## Dependencies
 

--- a/docs/token-tracking.md
+++ b/docs/token-tracking.md
@@ -71,8 +71,8 @@ cx.global::<GlobalTokenBudget>().update_with_actuals(input_tokens, output_tokens
 
 ## Research connection (GEPA / ACE)
 
-Context headroom and token cost feed optimizer economics ([cost model](../research/cost-model.md))
-and ACE playbook growth bounds. See [app ↔ research bridge](../research/app-research-bridge.md#context-window--token-budget).
+Context headroom and token cost feed optimizer economics ([cost model](research/cost-model.md))
+and ACE playbook growth bounds. See [app ↔ research bridge](research/app-research-bridge.md#context-window--token-budget).
 
 ## `TokenBudgetSnapshot`
 

--- a/scripts/check-docs-links.sh
+++ b/scripts/check-docs-links.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# AGE-117: verify markdown links in source docs (not synced mdBook copies).
+# Requires: lychee (https://github.com/lycheeverse/lychee)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if ! command -v lychee >/dev/null 2>&1; then
+  echo "lychee not found; install with: cargo install lychee --locked"
+  exit 1
+fi
+
+bash scripts/gen-docs-reference.sh
+
+# Source-of-truth paths only. docs-site/src copies rewrite relative paths and
+# would duplicate checks; mdBook HTML pulls in RESERVED via cross-links.
+lychee \
+  --config .lychee.toml \
+  --offline \
+  --no-progress \
+  'docs/**/*.md' \
+  'AGENTS.md' \
+  'CLAUDE.md' \
+  'CONTRIBUTING.md' \
+  'crates/*/README.md' \
+  'docs-site/src/index.md' \
+  'docs-site/src/user/**/*.md' \
+  'docs-site/src/dev/guides/**/*.md' \
+  'docs-site/src/dev/where-to-look.md'
+
+echo "docs link check: OK"

--- a/scripts/check-docs-nav-drift.sh
+++ b/scripts/check-docs-nav-drift.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# AGE-116: fail when docs/INDEX.md or docs-site/src/SUMMARY.md drift from repo markdown.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail=0
+INDEX="docs/INDEX.md"
+SUMMARY="docs-site/src/SUMMARY.md"
+
+if [[ ! -f "$INDEX" ]]; then
+  echo "missing $INDEX"
+  exit 1
+fi
+if [[ ! -f "$SUMMARY" ]]; then
+  echo "missing $SUMMARY"
+  exit 1
+fi
+
+# docs-sync must run first so docs-site/src reflects docs/ + crate READMEs.
+bash scripts/docs-sync.sh >/dev/null
+
+check_index() {
+  local missing=0
+  while IFS= read -r -d '' f; do
+    rel="${f#docs/}"
+    # INDEX lists paths like `foo.md` or `research/bar.md`
+    if ! grep -qF "$rel" "$INDEX"; then
+      echo "INDEX drift: docs/$rel not listed in $INDEX"
+      missing=$((missing + 1))
+    fi
+  done < <(find docs -name '*.md' \
+    ! -path 'docs/generated/*' \
+    ! -name 'INDEX.md' \
+    -print0)
+
+  if [[ "$missing" -gt 0 ]]; then
+    fail=1
+    echo "  → add a row to docs/INDEX.md for each file above"
+  else
+    echo "INDEX nav check: OK"
+  fi
+}
+
+check_summary() {
+  local missing=0
+  while IFS= read -r -d '' f; do
+    base="${f#docs-site/src/}"
+    [[ "$base" == "SUMMARY.md" ]] && continue
+    # SUMMARY uses mdBook paths like ./dev/agents.md
+    if ! grep -qF "./${base}" "$SUMMARY"; then
+      echo "SUMMARY drift: docs-site/src/$base not linked in $SUMMARY"
+      missing=$((missing + 1))
+    fi
+  done < <(find docs-site/src -name '*.md' -print0)
+
+  if [[ "$missing" -gt 0 ]]; then
+    fail=1
+    echo "  → add an entry to docs-site/src/SUMMARY.md for each file above"
+  else
+    echo "SUMMARY nav check: OK"
+  fi
+}
+
+check_index
+check_summary
+exit "$fail"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements two Linear doc-hygiene issues:

- **AGE-117** — offline link checker in CI (`scripts/check-docs-links.sh`, lychee)
- **AGE-116** — nav drift checks for `docs/INDEX.md` and `docs-site/src/SUMMARY.md`

### Changes

- `scripts/check-docs-links.sh` — lychee offline check on source docs
- `scripts/check-docs-nav-drift.sh` — fails when INDEX/SUMMARY are out of sync
- `.lychee.toml` — config with harbor-chatty / Linear exclusions
- `.github/workflows/docs.yml` — runs both checks on docs PRs
- `make docs-check-links` / `make docs-check-nav` + AGENTS.md updates
- Link fixes in `docs/agent-memory.md`, `docs/token-tracking.md`, `docs-site/src/index.md`
- `docs/INDEX.md` extended with M0–M4 module rows and crate README section

### Verification

```
bash scripts/check-docs-links.sh
bash scripts/check-docs-nav-drift.sh
make docs
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04c37-d111-7075-91c6-3d184124dc4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04c37-d111-7075-91c6-3d184124dc4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

