### PR TITLE
docs: finish Epic 2 migration (AGE-83/96 user guides + crate index)

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -15,7 +15,7 @@ edit the source files and rebuild.
 | `src/dev/reference/*.md` | Regenerate via `make docs-gen` |
 | `src/dev/crates/*.md` | `crates/*/README.md` |
 
-Hand-written pages (edit in place): `src/index.md`, `src/user/*`, `src/dev/guides/*`, `src/dev/where-to-look.md`.
+Hand-written pages (edit in place): `src/index.md`, `src/user/*`, `src/dev/guides/*`, `src/dev/where-to-look.md`, `src/dev/crates.md`.
 
 ## Commands
 

--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -7,8 +7,15 @@
 # User guides
 
 - [Getting started](./user/getting-started.md)
+- [Why Chatty?](./user/overview.md)
+- [Agents](./user/agents.md)
 - [Providers & models](./user/providers-and-models.md)
 - [Agentic tools](./user/agentic-tools.md)
+- [Memory & skills](./user/memory-and-skills.md)
+- [Sub-agents](./user/sub-agents.md)
+- [Security & sandboxing](./user/security.md)
+- [Features](./user/features.md)
+- [Terminal interface](./user/terminal.md)
 
 ---
 
@@ -49,6 +56,7 @@
 
 # Crates
 
+- [Workspace crate index](./dev/crates.md)
 - [chatty-core](./dev/crates/chatty-core.md)
 - [chatty-gpui](./dev/crates/chatty-gpui.md)
 - [chatty-tui](./dev/crates/chatty-tui.md)
@@ -82,6 +90,7 @@
 
 # ADRs & research
 
+- [ADR index (pair review)](./dev/adrs/README.md)
 - [Harbor pivot](./dev/adrs/harbor-pivot.md)
 - [chatty-trace promises](./dev/adrs/crate-promises-chatty-trace.md)
 - [chatty-playbook promises](./dev/adrs/crate-promises-chatty-playbook.md)

--- a/docs-site/src/dev/crates.md
+++ b/docs-site/src/dev/crates.md
@@ -1,0 +1,65 @@
+# Workspace crates
+
+**When to read this:** You need a one-glance map of the 13 workspace crates and where to dive deeper.
+
+Each crate has a README synced into this site on `make docs-sync`. Edit the source at `crates/<name>/README.md`, not the built copy under `dev/crates/`.
+
+## Application crates
+
+| Crate | Purpose | README |
+|-------|---------|--------|
+| [chatty-core](./crates/chatty-core.md) | UI-agnostic agent core: models, services, tools, settings, sandbox | `crates/chatty-core/` |
+| [chatty-gpui](./crates/chatty-gpui.md) | GPUI desktop app — ships the `chatty` binary | `crates/chatty-gpui/` |
+| [chatty-tui](./crates/chatty-tui.md) | Ratatui terminal app — interactive, headless, and pipe modes | `crates/chatty-tui/` |
+
+## WASM modules & protocols
+
+| Crate | Purpose | README |
+|-------|---------|--------|
+| [chatty-wasm-runtime](./crates/chatty-wasm-runtime.md) | Wasmtime embedding and host-side WIT interfaces | `crates/chatty-wasm-runtime/` |
+| [chatty-module-registry](./crates/chatty-module-registry.md) | Module discovery, manifest, and lifecycle | `crates/chatty-module-registry/` |
+| [chatty-protocol-gateway](./crates/chatty-protocol-gateway.md) | HTTP gateway: OpenAI / MCP / A2A protocol surfaces | `crates/chatty-protocol-gateway/` |
+| [chatty-module-sdk](./crates/chatty-module-sdk.md) | SDK for authoring `wasm32-wasip2` agent modules | `crates/chatty-module-sdk/` |
+
+## Research crates (Self-improving chatty2)
+
+Reserved symbols and human-only entry points are listed in [`RESERVED.md`](https://github.com/boersmamarcel/chatty2/blob/main/RESERVED.md). Linear project: [Self-improving chatty2](https://linear.app/agents-research/project/self-improving-chatty2).
+
+| Crate | Purpose | README |
+|-------|---------|--------|
+| [chatty-trace](./crates/chatty-trace.md) | Trace capture, ATIF export, feedback hooks (M0) | `crates/chatty-trace/` |
+| [chatty-playbook](./crates/chatty-playbook.md) | ACE-style playbook memory for evolving instructions (M4) | `crates/chatty-playbook/` |
+| [chatty-flow](./crates/chatty-flow.md) | AFlow workflow representation and IR (M2) | `crates/chatty-flow/` |
+| [chatty-optimize](./crates/chatty-optimize.md) | GEPA/AFlow optimizers, paired stats, QA loaders (M3) | `crates/chatty-optimize/` |
+
+## Hive integration
+
+| Crate | Purpose | README |
+|-------|---------|--------|
+| [hive-client](./crates/hive-client.md) | Open-source client for the Hive module registry | `crates/hive-client/` |
+| [hive-billing-sdk](./crates/hive-billing-sdk.md) | Publisher SDK for Hive billing in WASM modules (separate `Cargo.lock`) | `crates/hive-billing-sdk/` |
+
+## Dependency direction
+
+```mermaid
+flowchart TB
+  gpui[chatty-gpui] --> core[chatty-core]
+  tui[chatty-tui] --> core
+  gateway[chatty-protocol-gateway] --> core
+  registry[chatty-module-registry] --> runtime[chatty-wasm-runtime]
+  runtime --> core
+  trace[chatty-trace] -.-> core
+  playbook[chatty-playbook] -.-> core
+  flow[chatty-flow] -.-> core
+  optimize[chatty-optimize] -.-> trace
+  optimize -.-> playbook
+  optimize -.-> flow
+```
+
+`chatty-core` never depends on a UI crate. Research crates integrate with production code but optimizer runs must not block the interactive chat path.
+
+## Related docs
+
+- [Workspace crate split](./architecture/workspace-crate-split.md) — why the split exists
+- [Component map](./architecture/component-map.md) — diagrams of how crates connect
+- [Research pipeline](./adrs/paper-to-product-pipeline.md) — paper → experiment → product flow

--- a/docs-site/src/dev/where-to-look.md
+++ b/docs-site/src/dev/where-to-look.md
@@ -27,6 +27,7 @@ flowchart TD
 |------------|------|
 | Understand the big picture | [system-overview.md](./architecture/system-overview.md) |
 | See component diagrams | [component-map.md](./architecture/component-map.md) |
+| Find a workspace crate | [crates.md](./crates.md) |
 | Add an LLM tool | [add-tool.md](./guides/add-tool.md) |
 | Add a provider | [add-provider.md](./guides/add-provider.md) |
 | Fix stream/cancel bugs | [stream-manager.md](./architecture/stream-manager.md) |

--- a/docs-site/src/index.md
+++ b/docs-site/src/index.md
@@ -17,7 +17,7 @@ a Rust desktop and terminal AI agent framework.
 | **Coding agents** | [Agent quick-start](./dev/agents.md) · [Doc index](./dev/doc-index.md) · [Component map](./dev/architecture/component-map.md) |
 | **Contributors** | [System overview](./dev/architecture/system-overview.md) · [Contributing patterns](./dev/contributing-patterns.md) |
 | **Research → product** | [App ↔ research bridge](./dev/adrs/app-research-bridge.md) · [Paper pipeline](./dev/adrs/paper-to-product-pipeline.md) · [Modules](./dev/research/modules/index.md) |
-| **End users** | [Marketing site](https://github.com/boersmamarcel/chatty) · [User guides](./user/getting-started.md) |
+| **End users** | [Getting started](./user/getting-started.md) · [Features](./user/features.md) · [Marketing site](https://github.com/boersmamarcel/chatty) |
 
 ## Documentation map
 

--- a/docs-site/src/user/agents.md
+++ b/docs-site/src/user/agents.md
@@ -1,0 +1,77 @@
+# Agents
+
+**When to read this:** Understand how the agent loop works and what agents can do autonomously.
+
+## How the agent loop works
+
+Each message builds a full agent with your configured tools and MCP servers, then runs a streaming multi-turn loop:
+
+```
+You send a message
+       │
+       ▼
+  Agent reasons → calls a tool
+       │
+       ▼
+  Tool executes (with approval if required)
+       │
+       ▼
+  Agent receives result → reasons again
+       │
+       ▼
+  ...repeats up to turn limit (default 10)...
+       │
+       ▼
+  Final answer streamed to you
+```
+
+Tool calls, inputs, outputs, and reasoning appear as collapsible trace blocks alongside the response.
+
+For multi-step tasks, the agent creates a **structured plan** (goal + ordered todos). A collapsible **Agent plan** panel shows each step's status and progress before the agent marks steps done and verifies completion.
+
+## What agents can do
+
+With tools enabled, an agent can:
+
+- **Explore and edit code** — read files, navigate directories, apply diffs, rename and delete
+- **Execute shell commands** — builds, tests, git, scripts inside a sandbox
+- **Write and run code** — Python, JavaScript, TypeScript, Rust, or Bash (MontySandbox fast path; Docker fallback for packages)
+- **Query data** — SQL over Parquet/CSV/JSON via DuckDB; read/write Excel, Word, PowerPoint
+- **Browse the web** — Tavily, Brave, or DuckDuckGo lite fallback; fetch and parse URLs
+- **Generate outputs** — charts, Typst PDFs, diagrams, inline images
+- **Remember and learn** — persistent memory across conversations ([memory & skills](./memory-and-skills.md))
+- **Delegate** — spawn [sub-agents](./sub-agents.md) for parallel work
+
+## Slash commands
+
+Type `/` in the chat input:
+
+| Command | What it does |
+|---------|--------------|
+| `/agent <prompt>` | Spawn a headless `chatty-tui` sub-agent |
+| `/compact` | Summarize older history to free context |
+| `/context` | Token usage, context fill, working directory |
+| `/add-dir <path>` | Expand workspace to another directory |
+| `/cwd` / `/cd <path>` | Show or change working directory |
+| `/new` / `/clear` | Fresh conversation |
+| `/copy` | Copy latest response to clipboard |
+| `[skill name]` | Invoke a saved skill from the picker |
+
+Full list: [slash commands reference](../dev/reference/slash-commands.md).
+
+## Extended thinking
+
+Models with chain-of-thought reasoning (e.g. Claude extended thinking) render `<thinking>` blocks as collapsible sections.
+
+## Context window management
+
+- **Fill bar** — segmented footer showing context by component (preamble, tools, history, latest message)
+- **Token popover** — hover for per-segment estimates and provider token counts
+- **`/compact`** — compress older messages when the window fills
+- **Max Context Window** — set per model in Settings → Models → Advanced to enable the fill bar
+
+## Next
+
+- [Agentic tools](./agentic-tools.md)
+- [Memory & skills](./memory-and-skills.md)
+- [Sub-agents](./sub-agents.md)

--- a/docs-site/src/user/features.md
+++ b/docs-site/src/user/features.md
@@ -1,0 +1,70 @@
+# Features
+
+**When to read this:** Product capabilities beyond the agent loop.
+
+## Multi-provider support
+
+Connect multiple LLM providers from one interface. Per-model capabilities (vision, PDF, temperature) are stored in `ModelConfig`. See [Providers & models](./providers-and-models.md).
+
+| Provider | Images | PDF | Temperature | Notes |
+|----------|:------:|:---:|:-----------:|-------|
+| OpenRouter | Per-model | Per-model | Yes | Routes to Anthropic, OpenAI, Google, Mistral, hundreds more |
+| Azure OpenAI | Yes | Lossy | Yes | API Key or Entra ID |
+| Ollama | Per-model | Per-model | — | Auto-detected, fully local |
+
+## Rich rendering
+
+- **Markdown** with full formatting
+- **Syntax-highlighted code** (30+ languages via tree-sitter) with one-click copy
+- **LaTeX math** — inline and block, rendered to SVG via Typst
+- **Mermaid diagrams** — 23 diagram types, theme-aware, copy as PNG
+- **Image and PDF** previews inline in chat
+
+## Tool call traces
+
+Every tool call is a collapsible trace block: name, arguments, output, duration, status. `apply_diff` calls show a visual diff (additions green, deletions red).
+
+## Conversations & cost tracking
+
+- Persistent SQLite storage (no Chatty-hosted sync)
+- Auto-generated titles, sidebar search, export to Markdown
+- Per-conversation cost in sidebar; per-message token usage
+- Regeneration tracking creates DPO preference pairs
+
+## Training data export
+
+Export agent conversations for fine-tuning pipelines.
+
+### ATIF (Agent Trajectory Interchange Format)
+
+Structured JSON for agent training: messages, tool calls, reasoning, timestamps, token metrics, feedback, regeneration pairs. Compatible with [Harbor Framework](https://harborframework.com/docs/agents/trajectory-format) workflows.
+
+### JSONL
+
+- **SFT** — ChatML format for OpenAI, Anthropic, Together AI, etc.
+- **DPO** — preference pairs from regenerated responses
+- Auto-deduplication on re-export
+
+| Platform | Export path |
+|----------|-------------|
+| macOS | `~/Library/Application Support/chatty/exports/` |
+| Linux | `~/.config/chatty/exports/` |
+| Windows | `%APPDATA%\chatty\exports\` |
+
+Enable auto-export in **Settings → Training Data**.
+
+## Environment secrets
+
+**Settings → Secrets** — key-value pairs injected into every agent shell session. The agent knows variable names but never sees values.
+
+## Themes & UI
+
+20+ themes with light/dark variants. Configurable font size.
+
+## Auto-updates
+
+Background checks against GitHub releases with SHA-256 verification. macOS replaces the app bundle and relaunches; Linux refreshes bundled `chatty-tui` on next launch when installed via the desktop app.
+
+## Demos
+
+Animated demos live on the **[marketing site](https://github.com/boersmamarcel/chatty)** (`assets/animations/`). GIF placement in docs is pending human review (DOC-15).

--- a/docs-site/src/user/getting-started.md
+++ b/docs-site/src/user/getting-started.md
@@ -2,14 +2,51 @@
 
 **When to read this:** You are an end user setting up Chatty for the first time.
 
-For product overview and downloads, see the **[marketing site](https://github.com/boersmamarcel/chatty)**.
+For product overview, see [Why Chatty?](./overview.md). For demos and marketing content, see the **[marketing site](https://github.com/boersmamarcel/chatty)**.
 
-## Quick steps
+## 1. Download
 
-1. **Download** the latest release from [GitHub Releases](https://github.com/boersmamarcel/chatty2/releases)
-2. **Add a provider** in Settings → Providers (OpenRouter, Ollama, Azure, etc.)
-3. **Add a model** in Settings → Models
-4. **Enable agentic tools** in Settings → Code Execution (workspace path + approval mode)
+Grab the latest release from [GitHub Releases](https://github.com/boersmamarcel/chatty2/releases):
+
+| Platform | Format |
+|----------|--------|
+| macOS (Intel & Apple Silicon) | `.dmg` installer |
+| Linux (x86_64) | `.tar.gz` archive |
+| Windows (x86_64) | `.exe` installer |
+
+## 2. Add a provider
+
+1. Click the **gear icon** in the title bar → **Settings**
+2. Go to **Providers** → **Add Provider** (OpenRouter, Ollama, Azure OpenAI, etc.)
+3. Paste your API key (Ollama connects locally — no key needed)
+
+## 3. Add a model
+
+1. **Settings → Models → Add Model**
+2. Pick a provider and enter a model ID (e.g. `gpt-4o`, `claude-sonnet-4-20250514`)
+3. Chatty auto-detects vision and PDF support
+
+See [Providers & models](./providers-and-models.md) for capability details.
+
+## 4. Start chatting
+
+Close Settings and send your first message. The start screen shows active capabilities — skills, MCP servers, agents, file access, web tools, memory, workspace status.
+
+- Type `/` for slash commands (`/clear`, `/compact`, `/context`, `/agent`, …)
+- Type `@` for file picker in the current working directory
+- Switch models with the selector at the bottom of the chat
+
+## 5. Enable agentic tools
+
+Off by default — enable in **Settings → Code Execution**:
+
+1. Set a **workspace directory** (absolute path)
+2. Toggle **code execution** on
+3. Choose **approval mode**: ask every time / auto-approve / deny all
+
+Optional: set a **per-chat working directory** via the folder icon in the chat input.
+
+For MontySandbox fast Python and Docker fallback, see [Security & sandboxing](./security.md).
 
 ## Desktop vs terminal
 
@@ -23,7 +60,11 @@ cargo run -p chatty-gpui    # desktop
 cargo run -p chatty-tui     # terminal
 ```
 
+Full terminal guide: [Terminal interface](./terminal.md).
+
 ## Next
 
+- [Why Chatty?](./overview.md)
+- [Agents](./agents.md)
 - [Providers & models](./providers-and-models.md)
 - [Agentic tools](./agentic-tools.md)

--- a/docs-site/src/user/memory-and-skills.md
+++ b/docs-site/src/user/memory-and-skills.md
@@ -1,0 +1,44 @@
+# Memory & skills
+
+**When to read this:** Use persistent memory and reusable agent procedures across conversations.
+
+## How memory works
+
+Memory is stored locally in a binary file ([memvid-core](https://crates.io/crates/memvid-core)). By default, retrieval uses full-text search; enable **Semantic Search** in Settings for vector similarity (requires an embedding provider).
+
+The agent calls `search_memory` when past context would help — facts, preferences, prior decisions, project conventions.
+
+| Tool | What it does |
+|------|--------------|
+| `remember` | Store a fact, note, or preference with optional title and tags |
+| `search_memory` | Retrieve memories via natural-language query |
+
+### Storage paths
+
+| Platform | Path |
+|----------|------|
+| macOS | `~/Library/Application Support/chatty/memory.mv2` |
+| Linux | `~/.local/share/chatty/memory.mv2` |
+| Windows | `%APPDATA%\chatty\memory.mv2` |
+
+Memory is on by default. Toggle in **Settings → Code Execution**.
+
+### Settings
+
+- **Memory Browser** — browse, search, delete entries in **Settings → Memory**
+- **Purge All Memory** — permanently delete all stored memories
+- **Semantic Search** — vector similarity when an embedding provider is configured
+
+## Skills — reusable procedures
+
+Skills are named, multi-step procedures for recurring tasks:
+
+- `save_skill` — store a procedure (e.g. `"deploy-to-staging"`, `"write-unit-tests"`)
+- `search_memory` + `read_skill` — discover and load skill instructions before executing
+- Skills appear in the `/` slash-command picker
+- Workspace skills can live in `.claude/skills/` alongside your code
+
+## Related
+
+- [Agentic tools](./agentic-tools.md) — full tools catalog
+- [Agents](./agents.md) — agent loop overview

--- a/docs-site/src/user/overview.md
+++ b/docs-site/src/user/overview.md
@@ -1,0 +1,33 @@
+# Why Chatty?
+
+**When to read this:** You want a product overview before diving into setup.
+
+For downloads and first-run steps, see [Getting started](./getting-started.md).
+
+## Designed for agentic work
+
+Chatty is built for multi-turn agents, not just chat. Your LLM can chain dozens of tool calls — read files, run shell commands, query databases, browse the web, write and execute code, generate charts and documents, spawn sub-agents — and return a complete answer. The app runs locally under your control; network access depends on the provider and tools you enable.
+
+## Your keys, your data
+
+No middleman, no subscriptions. Chatty talks directly to OpenRouter, Azure OpenAI, your local Ollama instance, and any MCP/A2A services you configure. Conversations and settings are stored locally; prompts, attachments, and tool results may still be sent to the remote providers or services you choose.
+
+## Native Rust performance
+
+Built on [GPUI](https://crates.io/crates/gpui), the GPU-accelerated framework behind the Zed editor — not an Electron wrapper. Instant startup, smooth scrolling, minimal memory footprint.
+
+## One app, every model
+
+Access hundreds of models through OpenRouter, Azure OpenAI, or Ollama from a single window. Switch models mid-conversation and use the right model for each task.
+
+## Real tool use, properly sandboxed
+
+Filesystem access, a bash shell, and MCP servers run within a workspace sandbox. On Linux, shell commands use [bubblewrap](https://github.com/containers/bubblewrap) namespace isolation. On macOS, they use `sandbox-exec` with policy profiles that block `.ssh`, `.aws`, and other sensitive directories. You choose the approval mode: ask every time, auto-approve, or deny all.
+
+## Privacy-aware by default
+
+Chatty does not run its own cloud relay or product telemetry. Conversations are stored in a local SQLite database. For a fully local setup, use Ollama and avoid networked tools; otherwise, data goes directly to the providers and services you enable.
+
+## Marketing site
+
+Product demos and GIFs remain on the **[marketing site](https://github.com/boersmamarcel/chatty)** until the README split review (DOC-15) is complete.

--- a/docs-site/src/user/providers-and-models.md
+++ b/docs-site/src/user/providers-and-models.md
@@ -25,5 +25,5 @@ Chatty stores per-model capabilities in `ModelConfig`:
 Defaults come from `ProviderType::default_capabilities()`; Ollama models are
 detected per-model via `/api/show`.
 
-Developer reference: [Provider matrix](../dev/reference/env-vars.md) ·
+Developer reference: [Provider matrix](../dev/reference/provider-matrix.md) ·
 [agent_factory](https://github.com/boersmamarcel/chatty2/tree/main/crates/chatty-core/src/factories/agent_factory).

--- a/docs-site/src/user/security.md
+++ b/docs-site/src/user/security.md
@@ -1,0 +1,48 @@
+# Security & sandboxing
+
+**When to read this:** Understand how Chatty constrains agent tool access.
+
+## Workspace sandboxing
+
+Filesystem and bash tools are scoped to the workspace directory you configure. The agent cannot read or write outside that boundary.
+
+## Shell sandboxing
+
+| Platform | Mechanism |
+|----------|-----------|
+| Linux | [bubblewrap](https://github.com/containers/bubblewrap) — separate process, network, and mount namespaces |
+| macOS | `sandbox-exec` — blocks `.ssh`, `.aws`, `.gnupg`, and other sensitive paths |
+
+Optional **network isolation** blocks shell commands from making network requests.
+
+## Code execution isolation
+
+| Path | When |
+|------|------|
+| **MontySandbox** | Simple stdlib Python on host (~5–50 ms) |
+| **Docker fallback** | JS/TS/Rust/Bash, or Python with third-party packages |
+
+Docker containers are fully isolated from host filesystem and network. MontySandbox runs with a memory cap and stripped environment, falling back to Docker on import errors.
+
+Configure in **Settings → Code Execution**.
+
+## Approval flows
+
+Side-effect tools (writes, shell, sub-agents) support three modes:
+
+| Mode | Behavior |
+|------|----------|
+| **Ask every time** | Prompt before each tool call |
+| **Auto-approve** | Run immediately — trusted workflows |
+| **Deny all** | Tools visible but blocked |
+
+## Secrets & key masking
+
+- **MCP API keys** — agent sees `has_api_key: true` but never the value
+- **User secrets** — Settings → Secrets inject into shell sessions; values never revealed in tool output or logs
+- **No product telemetry** — network traffic goes only to providers, MCP/A2A services, and endpoints you configure
+
+## Related
+
+- [Agentic tools](./agentic-tools.md)
+- [Sub-agents](./sub-agents.md)

--- a/docs-site/src/user/sub-agents.md
+++ b/docs-site/src/user/sub-agents.md
@@ -1,0 +1,49 @@
+# Sub-agents
+
+**When to read this:** Delegate parallel or isolated subtasks to headless `chatty-tui` agents.
+
+## Why sub-agents?
+
+- **Parallelism** — independent subtasks run concurrently
+- **Isolation** — separate context and tools; mistakes don't pollute the parent conversation
+- **Composition** — chain agents where one output feeds the next
+- **Specialization** — focused prompts and toolsets per sub-agent
+
+## From the desktop UI
+
+Type `/agent <your prompt>` to launch a headless sub-agent inline.
+
+## Via the `sub_agent` tool
+
+The LLM can spawn sub-agents programmatically:
+
+```
+Task: "Refactor all modules and write tests for each"
+
+→ sub_agent("Refactor authentication module and write tests")
+→ sub_agent("Refactor billing module and write tests")
+→ sub_agent("Refactor notifications module and write tests")
+→ Parent merges results into final summary
+```
+
+Each sub-agent is a full `chatty-tui --headless` process with the same configured tools and models. Sub-agents can spawn further sub-agents.
+
+## From the terminal
+
+```bash
+# Single headless call
+chatty-tui --headless -m "Summarize the changes in the last 5 commits"
+
+# Pipe input
+git diff HEAD~3 | chatty-tui --pipe
+
+# Chain agents
+chatty-tui --headless -m "List all TODO comments in src/" | chatty-tui --pipe
+```
+
+See [Terminal interface](./terminal.md) for install, modes, and keybindings.
+
+## Related
+
+- [Agents](./agents.md)
+- [Security](./security.md) — approval flows for `sub_agent`

--- a/docs-site/src/user/terminal.md
+++ b/docs-site/src/user/terminal.md
@@ -1,0 +1,86 @@
+# Terminal interface (`chatty-tui`)
+
+**When to read this:** Use Chatty from the terminal — interactive, headless, or piped.
+
+`chatty-tui` shares provider and model configuration with the desktop app.
+
+## Modes
+
+| Mode | Command | Description |
+|------|---------|-------------|
+| **Interactive** | `chatty-tui` | Full-screen TUI with scrollable chat, model picker, approvals |
+| **Headless** | `chatty-tui --headless -m "question"` | Single message → stdout (scripts, sub-agents) |
+| **Pipe** | `cat file.rs \| chatty-tui --pipe` | Read stdin as message, print response |
+
+## Zero-config quick start
+
+Connect directly to a running model server — no desktop setup:
+
+```bash
+# Ollama (auto-discovers localhost:11434)
+chatty-tui --ollama
+chatty-tui --ollama --model llama3.2
+
+# vLLM / llama.cpp / LM Studio (OpenAI-compatible)
+chatty-tui --openai-compat-url http://localhost:8000
+chatty-tui --openai-compat-url http://localhost:8000 --model my-model --api-key sk-...
+```
+
+## Installing
+
+| Method | How |
+|--------|-----|
+| **Desktop app** | macOS: Chatty menu → Install CLI. Linux/Windows: Settings → General → Install CLI |
+| **Releases** | Same package as desktop app includes `chatty-tui` |
+| **Source** | `cargo install --path crates/chatty-tui` |
+
+Installed to `~/.local/bin` on Linux or your user bin directory on Windows.
+
+## Welcome screen & status bar
+
+Interactive mode with an empty conversation shows: active model, context window, workspace, git branch, enabled tools, internet capabilities, runtime features (memory, modules, agents). MCP and memory load in the background — badges show `⟳` while initializing.
+
+Status bar: app version, cwd (truncated), git branch. Footer hints update during streaming (`Ctrl+C stop`).
+
+## Keybindings (interactive)
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Send message |
+| `/` | Slash-command picker |
+| `@` | File picker (filter with typing) |
+| `PageUp`/`PageDown`, `Shift+↑/↓`, mouse wheel | Scroll |
+| `End` | Jump to bottom, resume auto-scroll |
+| `y` / `n` | Approve / deny tool prompt |
+| `Ctrl+C` | Stop streaming (or quit if idle) |
+| `Ctrl+Q` | Quit immediately |
+
+Launch overrides: `--enable tool1,tool2` / `--disable tool1,tool2`.
+
+## Slash commands (TUI)
+
+| Command | Action |
+|---------|--------|
+| `/model [query]` | Switch model |
+| `/tools [name]` | Toggle tool groups |
+| `/modules [show\|enable\|disable\|dir\|port]` | Module runtime settings |
+| `/add-dir <dir>` | Expand workspace |
+| `/agent <prompt>` | Headless sub-agent |
+| `/clear`, `/new` | Fresh conversation |
+| `/compact` | Summarize older messages |
+| `/context` | Token usage and cwd |
+| `/copy` | Copy latest response |
+| `/update` | CLI auto-update |
+| `/cwd`, `/cd [dir]` | Show or change cwd |
+| `/quit`, `/exit` | Quit |
+
+## Config sharing
+
+`chatty-tui` reads the same config as the desktop app (`~/.config/chatty/` or platform equivalent). Run the desktop app once to set up providers, or use `--ollama` / `--openai-compat-url` to skip configuration.
+
+CLI reference: [cli-flags.md](../dev/reference/cli-flags.md).
+
+## Related
+
+- [Sub-agents](./sub-agents.md)
+- [Getting started](./getting-started.md)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -58,6 +58,30 @@ for coding patterns and behavioural rules read
 | [`research/cost-model.md`](research/cost-model.md) | Optimizer economics | Cost model |
 | [`research/appworld-decision.md`](research/appworld-decision.md) | Eval sandbox choice | AppWorld decision |
 
+## Workspace crates
+
+One-line map of all 13 workspace crates. Full index with dependency diagram:
+[crates.md](https://github.com/boersmamarcel/chatty2/blob/main/docs-site/src/dev/crates.md)
+(mdBook: **Crates → Workspace crate index**).
+
+| Crate | Purpose |
+|---|---|
+| `chatty-core` | UI-agnostic agent core: models, services, tools, settings, sandbox |
+| `chatty-gpui` | GPUI desktop app (`chatty` binary) |
+| `chatty-tui` | Ratatui terminal app (interactive, headless, pipe) |
+| `chatty-wasm-runtime` | Wasmtime embedding and host WIT interfaces |
+| `chatty-module-registry` | WASM module discovery, manifest, lifecycle |
+| `chatty-protocol-gateway` | HTTP gateway: OpenAI / MCP / A2A |
+| `chatty-module-sdk` | SDK for `wasm32-wasip2` agent modules |
+| `chatty-trace` | Research: trace capture, ATIF export, feedback (M0) |
+| `chatty-playbook` | Research: ACE playbook memory (M4) |
+| `chatty-flow` | Research: AFlow workflow IR (M2) |
+| `chatty-optimize` | Research: GEPA/AFlow optimizers, paired stats (M3) |
+| `hive-client` | Hive module registry client |
+| `hive-billing-sdk` | Hive billing SDK for WASM publishers |
+
+Per-crate READMEs: `crates/<name>/README.md` (synced to mdBook on build).
+
 ## Generated reference (`docs/generated/`)
 
 Regenerate with `make docs-gen`. Synced into the mdBook site on build.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,34 @@
+# ADRs & research decisions
+
+**When to read this:** You need context on research architecture, crate boundaries, or Stage B eval placement.
+
+> **Pair review pending (DOC-13 / AGE-95):** These pages were migrated from `docs/research/` into the mdBook site. Marcel reviews tone and accuracy before treating them as final ADRs. Do not close this issue until review is complete.
+
+## Linear project
+
+All research crates and experiment protocol live under the **[Self-improving chatty2](https://linear.app/agents-research/project/self-improving-chatty2)** Linear project.
+
+Stage B sandboxes (HumanEval, Polyglot, AppWorld, …) are in the sibling repo [`harbor-chatty`](https://github.com/boersmamarcel/harbor-chatty) — see [Harbor pivot](./harbor-pivot.md).
+
+## Decision records
+
+| Doc | Topic |
+|-----|-------|
+| [harbor-pivot.md](./harbor-pivot.md) | Stage B eval lives in Harbor, not chatty2 |
+| [crate-promises-chatty-trace.md](./crate-promises-chatty-trace.md) | chatty-trace scope and boundaries |
+| [crate-promises-chatty-playbook.md](./crate-promises-chatty-playbook.md) | chatty-playbook scope and boundaries |
+| [crate-promises-chatty-flow.md](./crate-promises-chatty-flow.md) | chatty-flow scope and boundaries |
+| [cost-model.md](./cost-model.md) | Optimizer economics |
+| [appworld-decision.md](./appworld-decision.md) | AppWorld eval sandbox choice |
+
+## Pipeline & integration
+
+| Doc | Topic |
+|-----|-------|
+| [app-research-bridge.md](./app-research-bridge.md) | Production app ↔ M0–M4 module map |
+| [paper-to-product-pipeline.md](./paper-to-product-pipeline.md) | SOTA → experiment → product spine |
+| [experiment-protocol.md](./experiment-protocol.md) | Stage A/B checklist, cost accounting |
+| [promotion-log.md](./promotion-log.md) | Marcel-only promotion verdicts |
+| [settings-integration-map.md](./settings-integration-map.md) | Settings ↔ research mechanisms |
+
+Module work breakdown: [modules/index.md](./modules/index.md) (M0–M4).

--- a/docs/user/README-SPLIT-TODO.md
+++ b/docs/user/README-SPLIT-TODO.md
@@ -1,0 +1,29 @@
+# README split — human review checklist (DOC-15 / AGE-97)
+
+**Owner:** `owner:human` — Marcel reviews tone and which GIFs move vs stay.
+
+## AI-completed (this migration)
+
+User guide pages now live under `docs-site/src/user/`:
+
+| Page | Source README section |
+|------|----------------------|
+| `getting-started.md` | Getting Started |
+| `overview.md` | Why Chatty? |
+| `agents.md` | Agents |
+| `agentic-tools.md` | Tools & MCP (summary) |
+| `memory-and-skills.md` | Agent Memory & Skills |
+| `sub-agents.md` | Sub-Agent Orchestration |
+| `security.md` | Security & Sandboxing |
+| `features.md` | Features |
+| `terminal.md` | chatty-tui — Terminal Interface |
+| `providers-and-models.md` | Features → Multi-Provider (existing) |
+
+## Remaining for human
+
+1. **Trim `README.md`** to ~80 lines: what Chatty is, marketing link, docs site link, releases, minimal dev quick-start.
+2. **GIF placement** — decide which `assets/animations/*.gif` stay in README vs move to user docs or marketing repo.
+3. **Tone pass** on migrated `/user/` pages (marketing voice vs docs voice).
+4. **Remove duplicated content** from README once links to docs site are in place.
+
+Published site: GitHub Pages mdBook (`make docs-serve` locally).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finishes Epic 2 (AGE-83) AI-owned scope: content migration + user guide structure.

### AGE-96 — Per-crate index
- `docs-site/src/dev/crates.md` — workspace crate index (13 crates + dependency diagram)
- `docs/INDEX.md` — workspace crates table
- SUMMARY.md wired with crate index

### AGE-95 — ADR scaffold (owner:pair, not closed)
- `docs/research/README.md` — ADR index with pair-review banner

### AGE-97 — User guide migration (owner:human, README trim deferred)
- 7 new user guide pages: overview, agents, memory-and-skills, sub-agents, security, features, terminal
- Expanded `getting-started.md`
- `docs/user/README-SPLIT-TODO.md` — human checklist for README trim

### Verification
```
make docs
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04c37-d111-7075-91c6-3d184124dc4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04c37-d111-7075-91c6-3d184124dc4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

