### PR TITLE
ci: skip compile on docs-only PRs and cut redundant Rust work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,99 @@
 name: CI
 
+# Required status check is the `test` job. Do not add workflow-level
+# `paths` / `paths-ignore` — a skipped workflow fails that check.
+# Docs-only (and other non-compile) diffs take the cheap path inside `test`.
+
 on:
   pull_request:
+    branches:
+      - main
+  push:
     branches:
       - main
 
 permissions:
   contents: read
+  pull-requests: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
 
 jobs:
-  test:
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect compile-relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - '**/.cargo/**'
+              - 'rust-toolchain'
+              - 'rust-toolchain.toml'
+              - 'clippy.toml'
+              - 'rustfmt.toml'
+              - 'modules/**/*.rs'
+              - 'modules/**/Cargo.toml'
+              - 'modules/**/Cargo.lock'
+              - 'wit/**'
+              - 'scripts/check-reserved.sh'
+              - 'scripts/check-rig-pins.sh'
+              - 'scripts/check-release-authz.sh'
+              - 'scripts/setup-linux.sh'
+              - '.github/workflows/ci.yml'
+              - 'Makefile'
+
+  test:
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Skip compile/test (no Rust-relevant changes)
+        if: needs.changes.outputs.rust != 'true'
+        run: |
+          echo "No compile-relevant files changed; skipping toolchain, tests, and clippy."
+          echo "The required \`test\` check still reports success."
+
+      - name: Checkout repository
+        if: needs.changes.outputs.rust == 'true'
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
+        if: needs.changes.outputs.rust == 'true'
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-wasip2
 
       - name: Cache cargo registry and build artifacts
-        uses: actions/cache@v4
+        if: needs.changes.outputs.rust == 'true'
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            modules/echo-agent/target
-          key: cargo-ci-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'modules/echo-agent/Cargo.toml') }}
-          restore-keys: |
-            cargo-ci-${{ runner.os }}-
+          shared-key: linux-ci
+          workspaces: |
+            .
+            modules/echo-agent
+          cache-on-failure: true
 
       - name: Install Linux dependencies
+        if: needs.changes.outputs.rust == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -55,71 +115,37 @@ jobs:
             libssl-dev \
             pkg-config
 
-      - name: Install wasm32-wasip2 target
-        run: rustup target add wasm32-wasip2
-
       - name: Build echo-agent WASM
+        if: needs.changes.outputs.rust == 'true'
         run: |
           cd modules/echo-agent
           cargo build --target wasm32-wasip2 --release
           cp target/wasm32-wasip2/release/echo_agent.wasm .
 
       - name: Run tests
+        if: needs.changes.outputs.rust == 'true'
         # CI has shown intermittent SIGTRAP in `chatty-core` tests when run in
         # parallel on GitHub-hosted runners; serialize tests for stability.
+        # chatty-tui clap --help is covered by `cli_smoke_tests` (no extra
+        # `cargo build -p chatty-tui`, which recompiled the bin without cfg(test)).
         run: cargo test --all-features -- --test-threads=1
 
-      - name: Build chatty-tui
-        run: cargo build -p chatty-tui
-
-      - name: Smoke test chatty-tui (--help exits 0)
-        # Verifies the binary starts and clap argument parsing works.
-        # Does not require a configured provider or LLM access.
-        run: ./target/debug/chatty-tui --help
-
       - name: Check formatting
+        if: needs.changes.outputs.rust == 'true'
         run: cargo fmt --check
 
       - name: Run clippy
+        if: needs.changes.outputs.rust == 'true'
         run: cargo clippy -- -D warnings
 
       - name: Check reserved symbols (AGE research)
+        if: needs.changes.outputs.rust == 'true'
         run: bash scripts/check-reserved.sh
 
       - name: Check rig exact-minor pins (AGE-26)
+        if: needs.changes.outputs.rust == 'true'
         run: bash scripts/check-rig-pins.sh
 
       - name: Check release authz gates (closed-system)
+        if: needs.changes.outputs.rust == 'true'
         run: bash scripts/check-release-authz.sh
-
-  # AGE-26: compile-only canary against crates.io latest rig (informational).
-  rig-canary:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev pkg-config libfontconfig1-dev
-
-      - name: Soft canary — cargo update rig + check chatty-core
-        run: |
-          cp Cargo.lock Cargo.lock.canary-bak
-          set +e
-          cargo update -p rig-core
-          cargo update -p rig-agent
-          cargo check -p chatty-core --lib
-          status=$?
-          set -e
-          mv Cargo.lock.canary-bak Cargo.lock
-          if [ "$status" -ne 0 ]; then
-            echo "rig canary: compile failed against updated rig (schedule a bump window)"
-            exit 1
-          fi
-          echo "rig canary: OK"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,16 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # Skip docs-only / markdown-only PRs (saves Claude minutes).
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "modules/**/*.rs"
+      - "modules/**/Cargo.toml"
+      - "scripts/**/*.sh"
+      - ".github/workflows/**"
+      - "Makefile"
 
 jobs:
   claude-review:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,10 @@ on:
       - 'crates/**/README.md'
       - 'scripts/docs-sync.sh'
       - 'scripts/gen-docs-reference.sh'
+      - 'scripts/check-docs-links.sh'
+      - 'scripts/check-docs-nav-drift.sh'
       - 'Makefile'
+      - '.lychee.toml'
       - '.github/workflows/docs.yml'
   pull_request:
     paths:
@@ -22,7 +25,10 @@ on:
       - 'crates/**/README.md'
       - 'scripts/docs-sync.sh'
       - 'scripts/gen-docs-reference.sh'
+      - 'scripts/check-docs-links.sh'
+      - 'scripts/check-docs-nav-drift.sh'
       - 'Makefile'
+      - '.lychee.toml'
       - '.github/workflows/docs.yml'
 
 permissions:
@@ -30,13 +36,16 @@ permissions:
   pages: write
   id-token: write
 
+# Do not share one "pages" group across every PR — that serialized 20-minute
+# jobs. Cancel stale PR builds; never cancel the main deploy mid-upload.
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -45,8 +54,10 @@ jobs:
           curl -fsSL https://github.com/rust-lang/mdBook/releases/download/v0.5.4/mdbook-v0.5.4-x86_64-unknown-linux-gnu.tar.gz \
             | tar xz -C /usr/local/bin
 
-      - name: Build chatty-tui for CLI reference
-        run: cargo build -p chatty-tui
+      - name: Install lychee
+        uses: taiki-e/install-action@v2
+        with:
+          tool: lychee
 
       - name: Generate reference pages
         run: bash scripts/gen-docs-reference.sh
@@ -58,9 +69,6 @@ jobs:
         run: |
           mdbook build docs-site
           install -m 644 docs/generated/llms.txt docs-site/book/llms.txt
-
-      - name: Install lychee
-        run: cargo install lychee --locked
 
       - name: Check documentation links
         run: bash scripts/check-docs-links.sh

--- a/.github/workflows/reserved.yml
+++ b/.github/workflows/reserved.yml
@@ -3,11 +3,16 @@ name: Reserved symbols
 # Fails if a function reserved in RESERVED.md has been implemented without either its
 # todo!("human: ...") marker or a `// HUMAN-WRITTEN: <symbol>` attestation.
 on:
-  push:
   pull_request:
+  push:
+    branches: [main]
 
 permissions:
   contents: read
+
+concurrency:
+  group: reserved-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-reserved:

--- a/.github/workflows/rig-canary.yml
+++ b/.github/workflows/rig-canary.yml
@@ -1,0 +1,65 @@
+name: Rig canary
+
+# AGE-26: compile-only canary against crates.io latest rig (informational).
+# Not part of the required `test` check. Weekly + when lockfile/manifests change
+# so every docs PR does not pay for a cold `cargo check`.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "Cargo.lock"
+      - "**/Cargo.toml"
+      - ".github/workflows/rig-canary.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rig-canary-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  rig-canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: linux-rig-canary
+          cache-targets: false
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config libfontconfig1-dev
+
+      - name: Soft canary — cargo update rig + check chatty-core
+        run: |
+          cp Cargo.lock Cargo.lock.canary-bak
+          set +e
+          cargo update -p rig-core
+          cargo update -p rig-agent
+          cargo check -p chatty-core --lib
+          status=$?
+          set -e
+          mv Cargo.lock.canary-bak Cargo.lock
+          if [ "$status" -ne 0 ]; then
+            echo "rig canary: compile failed against updated rig (schedule a bump window)"
+            exit 1
+          fi
+          echo "rig canary: OK"

--- a/.github/workflows/ui-sync-check.yml
+++ b/.github/workflows/ui-sync-check.yml
@@ -4,6 +4,15 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "docs-site/**"
+      - "**/*.md"
+      - ".github/workflows/**"
+      - ".lychee.toml"
+      - "scripts/docs-sync.sh"
+      - "scripts/gen-docs-reference.sh"
+      - "scripts/check-docs-*.sh"
 
 jobs:
   sync-check:

--- a/.github/workflows/update-agent-docs.yml
+++ b/.github/workflows/update-agent-docs.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "docs-site/**"
+      - "**/*.md"
+      - ".github/workflows/docs.yml"
+      - ".lychee.toml"
 
 jobs:
   update-agent-docs:

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "docs-site/**"
+      - "**/*.md"
+      - ".github/workflows/docs.yml"
+      - ".lychee.toml"
 
 jobs:
   update-readme:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,10 @@ trait impls live behind the `gpui-globals` feature.
 **The CI workflow** ([`.github/workflows/ci.yml`](.github/workflows/ci.yml))
 **is the ground truth.** If a command is not here, it is not what CI runs.
 
+Docs-only PRs (and other diffs that do not match the Rust path filter in
+`ci.yml`) skip compile, test, and clippy. The required `test` check still
+goes green. Stale CI runs on the same PR are cancelled on the next push.
+
 ```bash
 make setup            # one-time: install Linux deps + wasm32-wasip2 target
 make build            # cargo build (debug)
@@ -119,7 +123,7 @@ make docs             # sync + build mdBook site (docs-site/book/)
 make docs-serve       # local preview at http://localhost:3000
 make docs-check-links # lychee link check (AGE-117)
 make docs-check-nav   # INDEX.md + SUMMARY.md drift check (AGE-116)
-make ci               # everything CI runs, locally, in order
+make ci               # everything the Rust CI path runs, locally, in order
 ```
 
 Or use cargo directly:
@@ -129,8 +133,6 @@ cargo build
 cargo test --all-features -- --test-threads=1
 cargo fmt --check
 cargo clippy -- -D warnings
-cargo build -p chatty-tui
-./target/debug/chatty-tui --help
 ```
 
 ### Test-thread footgun

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,10 +177,11 @@ sudo apt-get install -y \
 
 | Workflow | Trigger | Purpose |
 |:---------|:--------|:--------|
-| **CI** (`ci.yml`) | PR to `main` | Tests, formatting check, clippy lints. Cargo dependencies and build artifacts are cached. |
+| **CI** (`ci.yml`) | PR / push to `main` | Tests, formatting, clippy. Docs-only diffs skip compile (required `test` job still passes). Stale PR runs are cancelled. `Swatinem/rust-cache` is warmed on `main`. |
 | **Prepare Release** (`prepare-release.yml`) | PR merged with `release:patch`/`release:minor`/`release:major` label, or manual `workflow_dispatch` | Bumps version via a `cut-release` PR (main is protected), generates changelog, tags, creates the GitHub Release, then calls Release via `workflow_call`. |
 | **Release** (`release.yml`) | Called by Prepare Release via `workflow_call`, or manual GitHub Release publish | Builds cross-platform artifacts (Linux AppImage, macOS DMG, Windows EXE), generates checksums, uploads to release. Cargo cached per platform. |
-| **Claude Code Review** (`claude-code-review.yml`) | PR opened/updated | Automated AI code review via Claude. |
+| **Claude Code Review** (`claude-code-review.yml`) | PR opened/updated (Rust/CI paths only) | Automated AI code review via Claude. Skipped for docs-only PRs. |
+| **Rig canary** (`rig-canary.yml`) | Weekly, or PR that touches Cargo manifests | Informational `cargo update` + `cargo check` against latest rig (AGE-26). |
 | **Claude** (`claude.yml`) | `@claude` mention on issues/PRs | Interactive AI assistance. |
 | **Update README** (`update-readme.yml`) | PR merged to `main` | Claude analyzes the diff; if user-facing features changed, opens a follow-up PR with README updates. Add `skip-readme` label to opt out. |
 | **Update Agent Docs** (`update-agent-docs.yml`) | PR merged to `main` | Claude analyzes the merged PR for guidance drift and opens a follow-up PR to sync `CLAUDE.md` / `AGENTS.md` when needed. Add `skip-agent-docs` label to opt out. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,11 @@ Thank you for contributing to [chatty2](https://github.com/boersmamarcel/chatty2
 ```bash
 make setup        # once on Linux
 make wasm-modules # before full test suite
-make ci           # same as GitHub Actions
+make ci           # same compile/test/lint path GitHub runs for Rust PRs
 ```
+
+Docs-only pull requests do not compile the workspace on GitHub. Run `make docs`
+and `make docs-check-links` for documentation changes.
 
 ## Pull requests
 

--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,9 @@ run-gpui:
 run-tui:
 	cargo run -p chatty-tui
 
-# Mirrors the order in .github/workflows/ci.yml.
+# Mirrors the Rust path in .github/workflows/ci.yml.
+# GitHub skips this compile/test path when a PR only touches docs.
 ci: wasm-modules test
-	cargo build -p chatty-tui
-	./target/debug/chatty-tui --help
 	$(MAKE) fmt-check
 	$(MAKE) lint
 	bash scripts/check-reserved.sh

--- a/crates/chatty-tui/src/main.rs
+++ b/crates/chatty-tui/src/main.rs
@@ -903,3 +903,20 @@ fn inject_discovered(
         models_list.push(mc);
     }
 }
+
+#[cfg(test)]
+mod cli_smoke_tests {
+    use super::Cli;
+    use clap::CommandFactory;
+
+    /// Replaces the old CI `cargo build -p chatty-tui && ./target/debug/chatty-tui --help`
+    /// step. `cargo test` already compiles this crate; a second non-test bin
+    /// build was rebuilding for ~15 minutes on GitHub-hosted runners.
+    #[test]
+    fn help_renders_and_names_core_modes() {
+        let help = Cli::command().render_long_help().to_string();
+        assert!(help.contains("chatty-tui"), "{help}");
+        assert!(help.contains("--headless"), "{help}");
+        assert!(help.contains("--pipe"), "{help}");
+    }
+}

--- a/docs-site/src/dev/guides/build-package.md
+++ b/docs-site/src/dev/guides/build-package.md
@@ -7,8 +7,11 @@
 ```bash
 make setup        # Linux deps + wasm32-wasip2 (once)
 make wasm-modules # echo-agent WASM for tests
-make ci           # matches GitHub Actions
+make ci           # matches the Rust path of GitHub Actions
 ```
+
+GitHub skips that compile path when a PR only changes docs. Use `make docs`
+and `make docs-check-links` for documentation-only work.
 
 ## Platform packages
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -87,7 +87,7 @@ Regenerate with `make docs-gen`. Synced into the mdBook site on build.
 |---|---|
 | `tools-catalog.md` | Look up LLM tool names |
 | `slash-commands.md` | `/` commands in GPUI |
-| `cli-flags.md` | `chatty-tui --help` |
+| `cli-flags.md` | `chatty-tui --help` when the binary is already built; otherwise a static fallback |
 | `env-vars.md` | `CHATTY_*` and related env vars |
 | `llms.txt` | Agent discovery index |
 

--- a/scripts/gen-docs-reference.sh
+++ b/scripts/gen-docs-reference.sh
@@ -134,6 +134,9 @@ cat > "$OUT/env-vars.md" << 'EOF'
 EOF
 
 # ── CLI flags (chatty-tui) ───────────────────────────────────────────────────
+# Prefer a live `--help` dump when the binary is already built. Docs CI does
+# not compile chatty-tui (18+ minutes); keep an existing generated page or
+# write a static fallback so `make docs` still works without a Rust toolchain.
 TUI_BIN="$ROOT/target/debug/chatty-tui"
 if [[ -x "$TUI_BIN" ]]; then
   {
@@ -145,6 +148,8 @@ if [[ -x "$TUI_BIN" ]]; then
     "$TUI_BIN" --help 2>/dev/null || true
     echo '```'
   } > "$OUT/cli-flags.md"
+elif [[ -f "$OUT/cli-flags.md" ]]; then
+  echo "gen-docs-reference: chatty-tui not built; keeping existing cli-flags.md"
 else
   cat > "$OUT/cli-flags.md" << 'EOF'
 # CLI reference (chatty-tui)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Recent docs-only PRs were each burning ~70–90 minutes of GitHub-hosted runners:

- **CI `test`**: ~51 minutes of `cargo test` / `cargo build -p chatty-tui` / clippy even when no Rust changed. The extra TUI build after tests was ~14 minutes by itself (recompile without `cfg(test)`).
- **CI `rig-canary`**: ~14 minutes of cold `cargo check` on every PR, including markdown.
- **Docs**: ~18 minutes `cargo build -p chatty-tui` plus ~3.5 minutes `cargo install lychee`, and all docs jobs shared one `pages` concurrency group so PRs serialized.
- **No cancel-in-progress** on CI, so each push on a docs PR started another 50-minute job.

The required status check is the `test` job, so the workflow cannot use top-level `paths-ignore` (a skipped workflow fails the check).

## Changes

- **`ci.yml`**: detect compile-relevant paths (`dorny/paths-filter`). Docs-only diffs skip toolchain/test/clippy; `test` still succeeds. Cancel stale PR runs. `Swatinem/rust-cache` warmed on `main`. Drop the redundant TUI binary rebuild (clap `--help` is a unit test).
- **`docs.yml`**: no Rust compile; install lychee from a prebuilt binary; per-PR concurrency (do not cancel the `main` Pages deploy).
- **`rig-canary.yml`**: weekly / lockfile PRs only, not every PR.
- **`reserved.yml`**: PR + `main` only (stop double-running on every feature-branch push).
- **Claude review / post-merge doc bots**: skip docs-only path sets.

## Verification

Measured on this PR vs a recent docs-only run on `main`:

| Workflow | Before | This PR |
|---|---|---|
| Docs | 21m 45s (`cargo build` + `cargo install lychee`) | **18s** |
| Rust CI `test` | 50–58 min (tests + extra TUI rebuild + clippy) | **38m 3s** (no TUI rebuild) |
| Docs-only Rust CI (expected after merge) | 50–58 min | **~10s** skip path (`test` still green) |

Path filter on this PR correctly set `rust=true` (`ci.yml`, `Makefile`, `main.rs`). Local `cargo test -p chatty-tui -- help_renders_and_names_core_modes` passed. Required checks `test`, `check-reserved`, and `guard` are green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f3dc2cb-2dfd-4f0d-b290-a3330a9b561e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f3dc2cb-2dfd-4f0d-b290-a3330a9b561e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

