### PR TITLE
docs: remaining Linear tickets (slash how-to, frontmatter lint, docs.rs status)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,7 @@ on:
       - 'scripts/gen-docs-reference.sh'
       - 'scripts/check-docs-links.sh'
       - 'scripts/check-docs-nav-drift.sh'
+      - 'scripts/check-docs-frontmatter.sh'
       - 'Makefile'
       - '.lychee.toml'
       - '.github/workflows/docs.yml'
@@ -27,6 +28,7 @@ on:
       - 'scripts/gen-docs-reference.sh'
       - 'scripts/check-docs-links.sh'
       - 'scripts/check-docs-nav-drift.sh'
+      - 'scripts/check-docs-frontmatter.sh'
       - 'Makefile'
       - '.lychee.toml'
       - '.github/workflows/docs.yml'
@@ -76,6 +78,9 @@ jobs:
 
       - name: Check docs nav drift (INDEX + SUMMARY)
         run: bash scripts/check-docs-nav-drift.sh
+
+      - name: Check doc frontmatter schema
+        run: bash scripts/check-docs-frontmatter.sh
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ make docs             # sync + build mdBook site (docs-site/book/)
 make docs-serve       # local preview at http://localhost:3000
 make docs-check-links # lychee link check (AGE-117)
 make docs-check-nav   # INDEX.md + SUMMARY.md drift check (AGE-116)
+make docs-check-frontmatter  # optional YAML frontmatter schema (AGE-115)
 make ci               # everything the Rust CI path runs, locally, in order
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 .PHONY: help setup build build-release test test-fast test-tui test-gpui \
         test-gateway lint fmt fmt-check typecheck wasm-modules run-gpui \
         run-tui ci clean docs-gen docs-sync docs docs-serve docs-check-links \
-        docs-check-nav
+        docs-check-nav docs-check-frontmatter
 
 help:
 	@echo "Common targets:"
@@ -39,6 +39,7 @@ help:
 	@echo "  make docs-serve    Local mdBook preview (port 3000)"
 	@echo "  make docs-check-links  Verify markdown links (lychee; AGE-117)"
 	@echo "  make docs-check-nav    Verify INDEX.md + SUMMARY.md completeness (AGE-116)"
+	@echo "  make docs-check-frontmatter  Validate optional doc YAML frontmatter (AGE-115)"
 	@echo "  make ci            Everything CI runs, in order"
 
 setup:
@@ -130,3 +131,6 @@ docs-check-links:
 
 docs-check-nav:
 	bash scripts/check-docs-nav-drift.sh
+
+docs-check-frontmatter:
+	bash scripts/check-docs-frontmatter.sh

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -17,6 +17,8 @@ edit the source files and rebuild.
 
 Hand-written pages (edit in place): `src/index.md`, `src/user/*`, `src/dev/guides/*`, `src/dev/where-to-look.md`, `src/dev/crates.md`.
 
+Optional YAML frontmatter (`audience`, `source_files`, `related`) is documented in `src/dev/guides/doc-frontmatter.md` and linted by `make docs-check-frontmatter`.
+
 ## Commands
 
 ```bash

--- a/docs-site/src/SUMMARY.md
+++ b/docs-site/src/SUMMARY.md
@@ -107,6 +107,7 @@
 - [Slash commands](./dev/reference/slash-commands.md)
 - [CLI flags (chatty-tui)](./dev/reference/cli-flags.md)
 - [Environment variables](./dev/reference/env-vars.md)
+- [Settings schema](./dev/reference/settings-schema.md)
 - [GPUI event catalog](./dev/reference/event-catalog.md)
 - [Singleton inventory](./dev/reference/singleton-inventory.md)
 
@@ -114,5 +115,8 @@
 
 - [Add a new LLM provider](./dev/guides/add-provider.md)
 - [Add a new LLM tool](./dev/guides/add-tool.md)
+- [Add a slash command](./dev/guides/add-slash-command.md)
+- [Add a desktop GPUI view](./dev/guides/add-gpui-view.md)
+- [Doc frontmatter schema](./dev/guides/doc-frontmatter.md)
 - [Debug streams & rendering](./dev/guides/debug-streams.md)
 - [Build & package](./dev/guides/build-package.md)

--- a/docs-site/src/dev/crates.md
+++ b/docs-site/src/dev/crates.md
@@ -4,6 +4,15 @@
 
 Each crate has a README synced into this site on `make docs-sync`. Edit the source at `crates/<name>/README.md`, not the built copy under `dev/crates/`.
 
+None of the workspace crates are published to [crates.io](https://crates.io) / [docs.rs](https://docs.rs) today. Research crates set `publish = false`. Until a crate is published, use the README on this site and `cargo doc -p <crate> --open` locally — do not add docs.rs badge URLs (they 404 and fail the link checker).
+
+| Crate | crates.io / docs.rs | Local rustdoc |
+|-------|---------------------|---------------|
+| Application + WASM + Hive crates | Unpublished | `cargo doc -p <crate> --open` |
+| `chatty-trace`, `chatty-playbook`, `chatty-flow`, `chatty-optimize` | `publish = false` | `cargo doc -p <crate> --open` |
+
+When a crate is published, add a docs.rs badge here and on its README, and keep the crate-level `//!` docs complete enough for docs.rs.
+
 ## Application crates
 
 | Crate | Purpose | README |

--- a/docs-site/src/dev/guides/add-gpui-view.md
+++ b/docs-site/src/dev/guides/add-gpui-view.md
@@ -1,0 +1,59 @@
+---
+audience: [contributor]
+source_files:
+  - crates/chatty-gpui/src/chatty/views/
+  - crates/chatty-gpui/src/chatty/controllers/app_controller/mod.rs
+  - docs/entity-communication.md
+related:
+  - ./dev/architecture/entity-communication.md
+  - ./dev/guides/add-slash-command.md
+---
+
+# Add a desktop GPUI view
+
+**When to read this:** Add a new panel, dialog, or sidebar surface in the
+desktop app.
+
+> **Pair review pending (DOC-32 / AGE-108):** Scaffold from
+> `docs/entity-communication.md` and existing views. Marcel reviews the
+> walkthrough against a real view (for example `SidebarView`) before this is
+> treated as the canonical how-to.
+
+## Steps
+
+1. Create the view under `crates/chatty-gpui/src/chatty/views/`
+   (`mod.rs` + `Render`). Export it from `views/mod.rs`.
+2. Define a typed event enum and `impl EventEmitter<YourEvent> for YourView`.
+3. Construct the entity with `cx.new(|cx| …)` in `ChattyApp` (or the parent
+   that owns the view). Store `Entity<YourView>` on the parent.
+4. Subscribe once in `ChattyApp::setup_callbacks()`:
+
+   ```rust
+   cx.subscribe(&self.your_view, |app, _view, event: &YourEvent, cx| {
+       match event {
+           YourEvent::DoThing => { app.handle_thing(cx); }
+       }
+   })
+   .detach();
+   ```
+
+5. Emit from the view with `cx.emit(YourEvent::DoThing)`. Call `cx.notify()`
+   after mutating view state so it re-renders.
+6. Compose the view in the parent's `Render` tree
+   (`.child(self.your_view.clone())`).
+
+## Rules
+
+- Entity-to-entity communication is **only** `EventEmitter` / `cx.subscribe()`.
+  No `Arc<dyn Fn>` between entities.
+- `IntoElement` widgets (row items, buttons) may take callbacks, but those
+  closures must `entity.update(cx, |_, cx| cx.emit(…))` on the parent entity.
+- Store `WeakEntity<T>` in globals, never a strong `Entity` (avoids cycles).
+- Use `cx.defer()` if you need to update an entity that is already being
+  updated.
+
+## Reference
+
+- [Entity communication](../architecture/entity-communication.md)
+- Existing emitters: `SidebarEvent`, `ChatInputEvent`, `StreamManagerEvent`
+  — [event catalog](../reference/event-catalog.md)

--- a/docs-site/src/dev/guides/add-slash-command.md
+++ b/docs-site/src/dev/guides/add-slash-command.md
@@ -1,0 +1,66 @@
+---
+audience: [contributor, agent]
+source_files:
+  - crates/chatty-gpui/src/chatty/views/chat_input/slash.rs
+  - crates/chatty-gpui/src/chatty/controllers/app_controller/slash_commands.rs
+  - crates/chatty-tui/src/engine/commands.rs
+related:
+  - ./dev/reference/slash-commands.md
+  - ./dev/guides/add-tool.md
+---
+
+# Add a slash command
+
+**When to read this:** Expose a new `/command` in the chat input. Desktop (GPUI) and
+terminal (TUI) register commands in **different** files — there is no shared
+command table.
+
+Full lookup table: [slash commands reference](../reference/slash-commands.md).
+
+## Two command shapes
+
+| Shape | Example | GPUI wiring | TUI wiring |
+|-------|---------|-------------|------------|
+| Immediate (no args) | `/compact` | Picker `execute_immediately: true` → `ChatInputEvent::SlashCommandSelected` → `handle_slash_command` | `Command` variant, no `Option<String>` |
+| Arg-based | `/agent <prompt>` | Picker inserts `/agent ` (does not execute) → user sends → `try_handle_arg_slash_command` | `Command::Agent(Option<String>)` |
+
+Skills from `.claude/skills/` appear in both pickers with a skill badge. Do not
+register a skill as a built-in command.
+
+## GPUI (desktop)
+
+1. Add a `SlashCommand` to `SLASH_COMMANDS` in
+   `crates/chatty-gpui/src/chatty/views/chat_input/slash.rs`
+   (`command`, `description`, `insert_text`, `execute_immediately`).
+2. Immediate commands: add a match arm in
+   `ChattyApp::handle_slash_command`
+   (`crates/chatty-gpui/src/chatty/controllers/app_controller/slash_commands.rs`).
+3. Arg-based commands: handle the prefix in
+   `ChattyApp::try_handle_arg_slash_command` in the same file. Return `true` so
+   the message is **not** forwarded to the LLM.
+4. `ChattyApp` already routes `ChatInputEvent::SlashCommandSelected` and
+   intercepts `Send` for arg-based commands — no extra subscribe.
+
+## TUI (terminal)
+
+1. Add a `Command` variant and a `parse_command` match arm in
+   `crates/chatty-tui/src/engine/commands.rs`.
+2. Handle the variant in the engine (same file / `ChatEngine`).
+3. The TUI slash menu builds from the same `Command` parse list plus skills
+   (`crates/chatty-tui/src/ui/input.rs`). If the new command should appear in
+   the `/` picker, add it there too.
+4. Add a parse test in `crates/chatty-tui/src/engine/helpers.rs`
+   (`parses_new_slash_commands`).
+
+TUI-only today: `/model`, `/tools`, `/modules`, `/update`, `/quit`, `/exit`.
+GPUI has no `/quit` (window chrome handles that).
+
+## Parity checklist
+
+- [ ] Same command string and argument syntax in both UIs, or document the
+      exception in [slash-commands.md](../reference/slash-commands.md)
+      (`scripts/gen-docs-reference.sh`)
+- [ ] Immediate vs arg-based behavior matches
+- [ ] Unknown `/foo` is ignored (TUI) or logged (GPUI) — never sent as a user
+      message if you claimed it as a command
+- [ ] `make docs-gen` after changing the reference table

--- a/docs-site/src/dev/guides/doc-frontmatter.md
+++ b/docs-site/src/dev/guides/doc-frontmatter.md
@@ -1,0 +1,47 @@
+---
+audience: [contributor, agent]
+source_files:
+  - scripts/check-docs-frontmatter.sh
+related:
+  - ./dev/doc-index.md
+  - ./dev/agents.md
+---
+
+# Doc frontmatter schema
+
+**When to read this:** Add or edit YAML frontmatter on a markdown doc page.
+
+Frontmatter is **optional**. Pages without it pass the lint. When a page
+starts with a `---` fence, the block must match this schema:
+
+```yaml
+---
+audience: [contributor, agent]
+source_files:
+  - crates/chatty-core/src/tools/mod.rs
+related:
+  - ./dev/reference/tools-catalog.md
+---
+```
+
+| Field | Required if fence present | Value |
+|-------|---------------------------|-------|
+| `audience` | yes | List; each item one of `contributor`, `agent`, `user` |
+| `source_files` | no | List of repo-relative paths the page describes |
+| `related` | no | List of related doc links or issue ids |
+
+Unknown keys fail the lint. Inline lists (`audience: [agent]`) and block
+lists (`- agent`) are both accepted.
+
+## Lint
+
+```bash
+make docs-check-frontmatter
+# or
+bash scripts/check-docs-frontmatter.sh
+```
+
+CI runs the same script in `.github/workflows/docs.yml` (AGE-115). The
+checker walks `docs/`, `docs-site/src/`, `AGENTS.md`, and `CLAUDE.md`.
+Synced copies under `docs-site/src/dev/architecture/` inherit whatever
+the source file in `docs/` has.

--- a/docs-site/src/dev/where-to-look.md
+++ b/docs-site/src/dev/where-to-look.md
@@ -30,6 +30,9 @@ flowchart TD
 | Find a workspace crate | [crates.md](./crates.md) |
 | Add an LLM tool | [add-tool.md](./guides/add-tool.md) |
 | Add a provider | [add-provider.md](./guides/add-provider.md) |
+| Add a slash command | [add-slash-command.md](./guides/add-slash-command.md) |
+| Add a GPUI view | [add-gpui-view.md](./guides/add-gpui-view.md) |
+| Look up a persisted setting | [settings-schema.md](./reference/settings-schema.md) |
 | Fix stream/cancel bugs | [stream-manager.md](./architecture/stream-manager.md) |
 | Fix rendering/layout | [debug_ui.md](./architecture/debug_ui.md) |
 | Look up a tool name | [tools-catalog.md](./reference/tools-catalog.md) |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -114,6 +114,7 @@ Regenerate with `make docs-gen`. Synced into the mdBook site on build.
 | `slash-commands.md` | `/` commands in GPUI |
 | `cli-flags.md` | `chatty-tui --help` when the binary is already built; otherwise a static fallback |
 | `env-vars.md` | `CHATTY_*` and related env vars |
+| `settings-schema.md` | Persisted settings JSON files, models, defaults (AGE-101 pair review) |
 | `event-catalog.md` | GPUI entity events and subscribers |
 | `singleton-inventory.md` | Process-global state and repositories |
 | `llms.txt` | Agent discovery index (curated links) |

--- a/scripts/check-docs-frontmatter.sh
+++ b/scripts/check-docs-frontmatter.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# AGE-115: validate optional YAML frontmatter on markdown doc pages.
+# Pages without a leading --- fence are skipped. Invalid fences fail the check.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+python3 - "$@" <<'PY'
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+ALLOWED_AUDIENCE = {"contributor", "agent", "user"}
+ALLOWED_KEYS = {"audience", "source_files", "related"}
+ROOT = Path(".").resolve()
+
+SCAN_PATHS = [
+    Path("docs"),
+    Path("docs-site/src"),
+    Path("AGENTS.md"),
+    Path("CLAUDE.md"),
+    Path("CONTRIBUTING.md"),
+]
+
+
+def iter_markdown() -> list[Path]:
+    files: list[Path] = []
+    for p in SCAN_PATHS:
+        if not p.exists():
+            continue
+        if p.is_file():
+            files.append(p)
+            continue
+        for f in p.rglob("*.md"):
+            if "docs/generated" in f.as_posix():
+                continue
+            files.append(f)
+    return sorted(files)
+
+
+def parse_scalar_list(raw: str) -> list[str] | str:
+    raw = raw.strip()
+    if raw.startswith("[") and raw.endswith("]"):
+        inner = raw[1:-1].strip()
+        if not inner:
+            return []
+        return [part.strip().strip("'\"") for part in inner.split(",") if part.strip()]
+    return raw.strip().strip("'\"")
+
+
+def parse_frontmatter(text: str) -> dict[str, object] | None:
+    if not text.startswith("---"):
+        return None
+    newline = "\n"
+    if text.startswith("---\r\n"):
+        rest = text[5:]
+        newline = "\r\n"
+    elif text.startswith("---\n"):
+        rest = text[4:]
+    else:
+        raise ValueError("opening --- must be on its own line")
+
+    closer = None
+    for token in ("\n---\n", "\n---\r\n", "\n---"):
+        idx = rest.find(token)
+        if idx != -1:
+            closer = (idx, token)
+            break
+    if closer is None:
+        raise ValueError("unclosed frontmatter fence")
+    body = rest[: closer[0]]
+    return parse_yaml_subset(body)
+
+
+def parse_yaml_subset(body: str) -> dict[str, object]:
+    data: dict[str, object] = {}
+    current_key: str | None = None
+    current_list: list[str] | None = None
+
+    def flush_list() -> None:
+        nonlocal current_key, current_list
+        if current_key is not None and current_list is not None:
+            data[current_key] = current_list
+        current_key = None
+        current_list = None
+
+    for raw_line in body.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        stripped = raw_line.lstrip()
+        if stripped.startswith("- "):
+            if current_list is None or current_key is None:
+                raise ValueError(f"list item without a key: {raw_line!r}")
+            current_list.append(stripped[2:].strip().strip("'\""))
+            continue
+        if ":" not in raw_line:
+            raise ValueError(f"expected key: value, got {raw_line!r}")
+        flush_list()
+        key, _, val = stripped.partition(":")
+        key = key.strip()
+        val = val.strip()
+        if not key:
+            raise ValueError("empty key")
+        if val == "":
+            current_key = key
+            current_list = []
+            continue
+        data[key] = parse_scalar_list(val)
+        current_key = None
+        current_list = None
+    flush_list()
+    return data
+
+
+def validate(data: dict[str, object], path: Path) -> list[str]:
+    errors: list[str] = []
+    unknown = sorted(set(data) - ALLOWED_KEYS)
+    if unknown:
+        errors.append(f"{path}: unknown frontmatter keys: {', '.join(unknown)}")
+    if "audience" not in data:
+        errors.append(f"{path}: missing required key 'audience'")
+    else:
+        audience = data["audience"]
+        if not isinstance(audience, list) or not audience:
+            errors.append(f"{path}: audience must be a non-empty list")
+        else:
+            bad = [a for a in audience if a not in ALLOWED_AUDIENCE]
+            if bad:
+                errors.append(
+                    f"{path}: audience values must be contributor|agent|user, got {bad}"
+                )
+    for key in ("source_files", "related"):
+        if key in data and not isinstance(data[key], list):
+            errors.append(f"{path}: {key} must be a list")
+    return errors
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+
+    errors: list[str] = []
+    checked = 0
+    skipped = 0
+    for path in iter_markdown():
+        text = path.read_text(encoding="utf-8")
+        try:
+            parsed = parse_frontmatter(text)
+        except ValueError as exc:
+            errors.append(f"{path}: {exc}")
+            continue
+        if parsed is None:
+            skipped += 1
+            continue
+        checked += 1
+        errors.extend(validate(parsed, path))
+
+    if errors:
+        print("frontmatter check failed:")
+        for err in errors:
+            print(f"  {err}")
+        return 1
+    print(f"frontmatter check: OK ({checked} pages with frontmatter, {skipped} without)")
+    return 0
+
+
+def self_test() -> int:
+    ok = parse_frontmatter(
+        "---\naudience: [agent]\nsource_files:\n  - foo.rs\nrelated: [a.md]\n---\n# Title\n"
+    )
+    assert ok == {
+        "audience": ["agent"],
+        "source_files": ["foo.rs"],
+        "related": ["a.md"],
+    }
+    assert parse_frontmatter("# no fence\n") is None
+    try:
+        parse_frontmatter("---\naudience: [agent]\n")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected unclosed fence to fail")
+    errs = validate({"audience": ["nope"]}, Path("x.md"))
+    assert errs
+    print("frontmatter self-test: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+PY

--- a/scripts/gen-docs-reference.sh
+++ b/scripts/gen-docs-reference.sh
@@ -89,23 +89,104 @@ PY
 cat > "$OUT/slash-commands.md" << 'EOF'
 # Slash commands
 
-**When to read this:** Look up chat input `/` commands in the GPUI desktop app.
+**When to read this:** Look up chat input `/` commands. GPUI and TUI do not share a command table — see [Add a slash command](../guides/add-slash-command.md).
 
-Source: `crates/chatty-gpui/src/chatty/controllers/app_controller/slash_commands.rs`
+Sources: `crates/chatty-gpui/src/chatty/views/chat_input/slash.rs`,
+`crates/chatty-gpui/src/chatty/controllers/app_controller/slash_commands.rs`,
+`crates/chatty-tui/src/engine/commands.rs`.
 
 | Command | Action | GPUI | TUI |
 |---------|--------|------|-----|
-| `/clear` | Start new conversation | Yes | — |
-| `/new` | Start new conversation | Yes | — |
-| `/compact` | Summarize oldest half of history | Yes | — |
-| `/context` | Show token/context usage | Yes | — |
-| `/copy` | Copy last assistant response | Yes | — |
-| `/cwd` | Show working directory | Yes | — |
-| `/cd` | Change per-chat working directory | Yes | — |
-| `/add-dir` | Add workspace directory | Yes | — |
-| `/agent` | Switch agent configuration | Yes | — |
+| `/clear` | Start new conversation | Yes | Yes |
+| `/new` | Start new conversation | Yes | Yes |
+| `/compact` | Summarize oldest half of history | Yes | Yes |
+| `/context` | Show token/context usage | Yes | Yes |
+| `/copy` | Copy last assistant response | Yes | Yes |
+| `/cwd` | Show working directory | Yes | Yes |
+| `/cd [dir]` | Change per-chat working directory | Yes | Yes |
+| `/add-dir <dir>` | Add workspace directory | Yes | Yes |
+| `/agent [name] <prompt>` | Launch local sub-agent or named A2A agent | Yes | Yes |
+| `/model [query]` | Switch / list models | — | Yes |
+| `/tools [name]` | Open tool picker or toggle by name | — | Yes |
+| `/modules …` | Module runtime settings | — | Yes |
+| `/update` | CLI auto-update | — | Yes |
+| `/quit` `/exit` | Quit the application | — | Yes |
 
-Skills from `.claude/skills/` appear in the picker with a `[skill]` badge.
+Skills from `.claude/skills/` appear in both pickers with a skill badge.
+EOF
+
+# ── Settings schema (AGE-101, pair review) ──────────────────────────────────
+cat > "$OUT/settings-schema.md" << 'EOF'
+---
+audience: [contributor, agent]
+source_files:
+  - crates/chatty-core/src/settings/repositories/mod.rs
+  - crates/chatty-core/src/settings/models/
+related:
+  - ./dev/reference/env-vars.md
+  - ./dev/adrs/settings-integration-map.md
+---
+
+# Settings schema reference
+
+**When to read this:** Find the JSON file, model, and defaults for a persisted
+setting.
+
+> **Pair review pending (DOC-23 / AGE-101):** Tables below are generated from
+> `settings/repositories/` + `settings/models/` as of this commit. Marcel
+> confirms file names, defaults, and which secrets must never appear in docs
+> examples before this page is treated as complete.
+
+## Config directory
+
+`dirs::config_dir()/chatty` — via `generic_json_repository::chatty_config_dir()`.
+
+| Platform | Typical path |
+|----------|----------------|
+| Linux | `~/.config/chatty/` (`$XDG_CONFIG_HOME/chatty`) |
+| macOS | `~/Library/Application Support/chatty/` (`dirs::config_dir`) |
+| Windows | `%APPDATA%\chatty\` |
+
+Missing files load `Default`. Saves are atomic (temp file + rename).
+
+Module **binaries** (WASM) live under `dirs::data_dir()/chatty/modules/`, not
+the config dir — see `ModuleSettingsModel`.
+
+## Single-object files (`load` / `save`)
+
+| File | Model | Key fields / defaults |
+|------|-------|------------------------|
+| `general_settings.json` | `GeneralSettingsModel` | `font_size` `14.0`; `theme_name` / `dark_mode` `None` |
+| `execution_settings.json` | `ExecutionSettingsModel` | `enabled` `false`; `approval_mode` `AlwaysAsk`; `workspace_dir` `None`; filesystem + fetch default **on**; git / execute_code / docker default **off**; `timeout_seconds` `30`; `max_output_bytes` `51200`; `max_agent_turns` `10`; `memory_enabled` `true` |
+| `search_settings.json` | `SearchSettingsModel` | `enabled` `false`; `active_provider` `Tavily`; API keys `None`; `max_results` `5` |
+| `training_settings.json` | `TrainingSettingsModel` | `atif_auto_export` / `jsonl_auto_export` `false` |
+| `user_secrets.json` | `UserSecretsModel` | secret key/value list — **do not log or paste real values** |
+| `hive_settings.json` | `HiveSettingsModel` | `registry_url` `http://localhost:8080`; `runner_url` `http://localhost:8081`; `token` `None` |
+| `extensions.json` | `ExtensionsModel` | enabled A2A / extension entries |
+| `module_settings.json` | `ModuleSettingsModel` | `enabled` `false`; `gateway_port` `8420`; `module_dir` = platform data dir (`~/Library/Application Support/chatty/modules` on macOS, `~/.local/share/chatty/modules` on Linux) |
+
+OAuth tokens: `mcp_oauth_<sanitized_name>.json` in the same config dir
+(`oauth_credential_json_repository`).
+
+## List files (`load_all` / `save_all`)
+
+| File | Item type | Notes |
+|------|-----------|--------|
+| `providers.json` | `ProviderConfig` | API keys live here; never expose to the LLM |
+| `models.json` | `ModelConfig` | per-model capabilities, preamble, temperature |
+| `mcp_servers.json` | `McpServerConfig` | use `masked_env()` on any LLM-facing copy |
+| `a2a_agents.json` | `A2aAgentConfig` | registered A2A agents |
+
+## Not persisted as JSON (yet)
+
+| Model | Notes |
+|-------|-------|
+| `TokenTrackingSettings` | In-memory global; defaults `enabled` `true`, reserve `4096`, high `0.70`, critical `0.90`, `auto_summarize` `false`. Comment in source says JSON persistence is a follow-up. |
+
+## Related
+
+- [Settings integration map](../adrs/settings-integration-map.md) — research ↔ settings
+- [Environment variables](./env-vars.md) — `CHATTY_*` / `XDG_*`
 EOF
 
 # ── Provider matrix ─────────────────────────────────────────────────────────
@@ -371,6 +452,7 @@ cat > "$OUT/llms.txt" << EOF
 - [Slash commands](${SITE_BASE}/dev/reference/slash-commands.html)
 - [CLI flags](${SITE_BASE}/dev/reference/cli-flags.html)
 - [Environment variables](${SITE_BASE}/dev/reference/env-vars.html)
+- [Settings schema](${SITE_BASE}/dev/reference/settings-schema.html)
 - [GPUI event catalog](${SITE_BASE}/dev/reference/event-catalog.html)
 - [Singleton inventory](${SITE_BASE}/dev/reference/singleton-inventory.html)
 
@@ -378,6 +460,7 @@ cat > "$OUT/llms.txt" << EOF
 
 - [Add a provider](${SITE_BASE}/dev/guides/add-provider.html)
 - [Add a tool](${SITE_BASE}/dev/guides/add-tool.html)
+- [Add a slash command](${SITE_BASE}/dev/guides/add-slash-command.html)
 - [Debug streams](${SITE_BASE}/dev/guides/debug-streams.html)
 - [Build & package](${SITE_BASE}/dev/guides/build-package.html)
 
@@ -423,6 +506,7 @@ append_section "Tools catalog" "$OUT/tools-catalog.md"
 append_section "GPUI event catalog" "$OUT/event-catalog.md"
 append_section "Singleton inventory" "$OUT/singleton-inventory.md"
 append_section "Environment variables" "$OUT/env-vars.md"
+append_section "Settings schema" "$OUT/settings-schema.md"
 append_section "Where do I…?" "$ROOT/docs-site/src/dev/where-to-look.md"
 
 echo "gen-docs-reference: wrote reference pages to $OUT"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes the last `owner:ai` tickets in **Chatty developer documentation** that were still open, and leaves pair/human work for Marcel.

## Closed by this PR (after merge)

- **AGE-109** — How-to: add a slash command (GPUI picker + `slash_commands.rs` vs TUI `Command` parse). Corrects the generated slash-command table so TUI parity is accurate (`/model`, `/tools`, `/quit`, …).
- **AGE-115** — Optional YAML frontmatter schema (`audience`, `source_files`, `related`) and `scripts/check-docs-frontmatter.sh` in docs CI + `make docs-check-frontmatter`.
- **AGE-120** — Workspace crates are **not** on crates.io/docs.rs. The crate index says so and points at `cargo doc` instead of 404 badges.

## Pair scaffolds (not closed)

- **AGE-108** — How-to: add a GPUI view (entity-communication walkthrough). Assigned to Marcel.
- **AGE-101** — Settings schema reference (JSON files, models, defaults). Assigned to Marcel.

## Already true on `main` (Linear only)

- **AGE-82** Epic 1 → Done (all children shipped).

## Local checks

- `make docs` (mdBook 0.5.4)
- `bash scripts/check-docs-nav-drift.sh`
- `bash scripts/check-docs-frontmatter.sh` (self-test + full scan)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f3dc2cb-2dfd-4f0d-b290-a3330a9b561e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f3dc2cb-2dfd-4f0d-b290-a3330a9b561e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

