### PR TITLE
chore: bump similar 3.2, nix 0.31, dirs 6.0 (#461)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,7 @@ dependencies = [
  "calamine 0.34.0",
  "chrono",
  "comemo 0.4.0",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "docx-rs",
  "duckdb",
  "flate2",
@@ -1737,7 +1737,7 @@ dependencies = [
  "memvid-core",
  "mermaid-rs-renderer",
  "mitex",
- "nix 0.29.0",
+ "nix 0.31.3",
  "parking_lot",
  "pdfium-render",
  "pptx",
@@ -1791,7 +1791,7 @@ dependencies = [
  "chatty-module-registry",
  "chatty-protocol-gateway",
  "chatty-wasm-runtime",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "flate2",
  "futures",
  "gpui",
@@ -1896,7 +1896,7 @@ dependencies = [
  "chatty-module-registry",
  "clap",
  "crossterm 0.29.0",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "futures",
  "ratatui",
  "rig-agent",
@@ -2245,7 +2245,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b60b5124979fccd9addd89d8b97a1d6eebb4950694520c75ddd722535ea443f"
 dependencies = [
- "nix 0.31.2",
+ "nix 0.31.3",
  "thiserror 2.0.18",
 ]
 
@@ -6264,9 +6264,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libduckdb-sys"
@@ -7097,9 +7097,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -10052,9 +10052,12 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "simplecss"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.50.0", features = ["rt", "rt-multi-thread", "fs", "macros", "process", "io-util"] }
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite"] }
-dirs = "5.0"
+dirs = "6.0"
 uuid = { version = "1.23.0", features = ["v4"] }
 
 # Docker sandbox
@@ -53,7 +53,7 @@ base64 = "0.22"
 async-stream = "0.3"
 reqwest = { version = "0.13.2", default-features = false, features = ["rustls", "json", "stream", "query"] }
 glob = "0.3"
-similar = "2.7.0"
+similar = "3.2.0"
 
 # Auto-updater
 semver = "1.0"
@@ -140,4 +140,4 @@ tui-textarea = { package = "tui-textarea-2", version = "0.10.2" }
 clap = { version = "4.6.0", features = ["derive"] }
 
 # Unix-specific
-nix = { version = "0.29", features = ["signal"] }
+nix = { version = "0.31.3", features = ["signal"] }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #461.

- `similar` 2.7 → 3.2.0
- `nix` 0.29 → 0.31.3
- `dirs` 5.0 → 6.0

Call sites unchanged.

**Note:** This branch conflicts with the other dependency-bump PRs on `Cargo.toml` / `Cargo.lock`. Merge sequentially onto `main`.

Verified: `cargo fmt --check`, `cargo check -p chatty-core -p chatty-tui`, `filesystem_service` tests (25 pass).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0e674ca-2ec5-44fb-91f6-52513f48ba8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0e674ca-2ec5-44fb-91f6-52513f48ba8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

